### PR TITLE
docs: Document the default behavior of the `build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ updated to install the crates.io package once a proper release is made.
 The `cargo component` subcommand has some analogous commands to cargo itself:
 
 * `cargo component new` — creates a new WebAssembly component Rust project.
-* `cargo component build` — builds a WebAssembly component from a Rust project.
+* `cargo component build` — builds a WebAssembly component from a Rust project
+  using the `wasm32-unknown-unknown` target by default.
 * (_coming soon_) `cargo component metadata` — prints package metadata as `cargo metadata` would,
   except it also includes the metadata of generated bindings.
 * (_coming soon_) `cargo component check` — checks the local package and all of its dependencies


### PR DESCRIPTION
Ran into a small error while testing, my rust installation was missing this target. I thought it might be useful to make it explicit. 