### PR TITLE
Implement `cargo component metadata` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `cargo component` subcommand has some analogous commands to cargo itself:
 * `cargo component new` — creates a new WebAssembly component Rust project.
 * `cargo component build` — builds a WebAssembly component from a Rust project
   using the `wasm32-unknown-unknown` target by default.
-* (_coming soon_) `cargo component metadata` — prints package metadata as `cargo metadata` would,
+* `cargo component metadata` — prints package metadata as `cargo metadata` would,
   except it also includes the metadata of generated bindings.
 * (_coming soon_) `cargo component check` — checks the local package and all of its dependencies
   (including generated bindings) for errors.

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use cargo::{CliError, Config};
-use cargo_component::commands::{BuildCommand, NewCommand};
+use cargo_component::commands::{BuildCommand, MetadataCommand, NewCommand};
 use clap::Parser;
 
 /// Cargo integration for WebAssembly components.
@@ -23,6 +23,7 @@ enum CargoComponent {
 pub enum Command {
     New(NewCommand),
     Build(BuildCommand),
+    Metadata(MetadataCommand),
 }
 
 fn main() -> Result<()> {
@@ -35,6 +36,7 @@ fn main() -> Result<()> {
         CargoComponent::Component(cmd) | CargoComponent::Command(cmd) => match cmd {
             Command::New(cmd) => cmd.exec(&mut config),
             Command::Build(cmd) => cmd.exec(&mut config),
+            Command::Metadata(cmd) => cmd.exec(&mut config),
         },
     } {
         cargo::exit_with_error(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,9 +6,11 @@ use cargo_util::paths::normalize_path;
 use std::path::{Path, PathBuf};
 
 mod build;
+mod metadata;
 mod new;
 
 pub use self::build::*;
+pub use self::metadata::*;
 pub use self::new::*;
 
 fn root_manifest(manifest_path: Option<&Path>, config: &Config) -> Result<PathBuf> {

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -1,0 +1,120 @@
+use crate::{commands::workspace, metadata};
+use anyhow::Result;
+use cargo::{core::resolver::CliFeatures, ops::OutputMetadataOptions, Config};
+use clap::Args;
+use std::path::PathBuf;
+
+/// Output the resolved dependencies of a package, the concrete used versions
+/// including overrides, in machine-readable format
+#[derive(Args)]
+#[clap(name = "build")]
+pub struct MetadataCommand {
+    /// Do not print cargo log messages
+    #[clap(long = "quiet", short = 'q')]
+    pub quiet: bool,
+
+    /// Space or comma separated list of features to activate
+    #[clap(long = "features", value_name = "FEATURES")]
+    pub features: Vec<String>,
+
+    /// Activate all available features
+    #[clap(long = "all-features")]
+    pub all_features: bool,
+
+    /// Do not activate the `default` feature
+    #[clap(long = "no-default-features")]
+    pub no_default_features: bool,
+
+    /// Only include resolve dependencies matching the given target triple
+    #[clap(long = "filter-platform")]
+    pub filter_platforms: Vec<String>,
+
+    /// Use verbose output (-vv very verbose/build.rs output)
+    #[clap(
+        long = "verbose",
+        short = 'v',
+        takes_value = false,
+        parse(from_occurrences)
+    )]
+    pub verbose: u32,
+
+    /// Coloring: auto, always, never
+    #[clap(long = "color", value_name = "WHEN")]
+    pub color: Option<String>,
+
+    /// Output information only about the workspace members and don't fetch dependencies
+    #[clap(long = "no-deps")]
+    pub no_deps: bool,
+
+    /// Require Cargo.lock and cache are up to date
+    #[clap(long = "frozen")]
+    pub frozen: bool,
+
+    /// Path to Cargo.toml
+    #[clap(long = "manifest-path", value_name = "PATH")]
+    pub manifest_path: Option<PathBuf>,
+
+    /// Format version
+    #[clap(long = "format-version", value_name = "VERSION", possible_values = ["1"])]
+    pub format_version: Option<u32>,
+
+    /// Require Cargo.lock is up to date
+    #[clap(long = "locked")]
+    pub locked: bool,
+
+    /// Run without accessing the network
+    #[clap(long = "offline")]
+    pub offline: bool,
+
+    /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+    #[clap(long = "Z", value_name = "FLAG")]
+    pub unstable_flags: Vec<String>,
+}
+
+impl MetadataCommand {
+    /// Executes the command.
+    pub fn exec(self, config: &mut Config) -> Result<()> {
+        log::debug!("executing metadata command");
+
+        config.configure(
+            self.verbose,
+            self.quiet,
+            self.color.as_deref(),
+            self.frozen,
+            self.locked,
+            self.offline,
+            &None,
+            &self.unstable_flags,
+            &[],
+        )?;
+
+        let workspace = workspace(None, config)?;
+
+        let version: u32 = match self.format_version {
+            Some(version) => version,
+            None => {
+                config.shell().warn(
+                    "please specify `--format-version` flag explicitly to avoid compatibility problems",
+                )?;
+                1
+            }
+        };
+
+        let options = OutputMetadataOptions {
+            cli_features: CliFeatures::from_command_line(
+                &self.features,
+                self.all_features,
+                !self.no_default_features,
+            )?,
+            no_deps: self.no_deps,
+            filter_platforms: self.filter_platforms,
+            version,
+        };
+
+        let metadata = metadata(config, workspace, &options)?;
+
+        config.shell().print_json(&metadata)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR implements the `metadata` subcommand for `cargo component`.

The command functions identically to `cargo metadata` except the returned
dependency information includes the generated bindings.