### PR TITLE
feat: Automatically install wasm32-unknown-unknown

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,6 +18,7 @@ pub use self::build::*;
 pub use self::check::*;
 pub use self::metadata::*;
 pub use self::new::*;
+use crate::target;
 
 fn root_manifest(manifest_path: Option<&Path>, config: &Config) -> Result<PathBuf> {
     match manifest_path {
@@ -136,6 +137,7 @@ impl CompileOptions {
         let spec = Packages::from_flags(self.workspace, self.exclude, self.packages)?;
 
         if self.targets.is_empty() {
+            target::install_wasm32_unknown_unknown()?;
             self.targets.push("wasm32-unknown-unknown".to_string());
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ use wit_bindgen_gen_rust_wasm::Opts;
 use wit_component::ComponentEncoder;
 use wit_parser::Interface;
 
+mod target;
+
 pub mod commands;
 
 const COMPONENT_PATH: &str = "package.metadata.component";

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,51 @@
+use anyhow::{bail, Result};
+use std::{env, path::PathBuf, process::{Command, Stdio}};
+
+pub fn install_wasm32_unknown_unknown() -> Result<()> {
+    let sysroot = get_sysroot()?;
+    if sysroot.join("lib/rustlib/wasm32-unknown-unknown").exists() {
+        return Ok(());
+    }
+
+    if env::var_os("RUSTUP_TOOLCHAIN").is_none() {
+        bail!(
+            "failed to find the `wasm32-unknown-unknown` target \
+               and `rustup` is not available. If you're using rustup \
+               make sure that it's correctly installed; if not, make sure to \
+               install the `wasm32-unknown-unknown` target before using this command"
+        );
+    }
+
+    let output = Command::new("rustup")
+        .arg("target")
+        .arg("add")
+        .arg("wasm32-unknown-unknown")
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .output()?;
+
+    if !output.status.success() {
+        bail!("failed to install the `wasm32-unknown-unknown` target");
+    }
+
+    Ok(())
+}
+
+fn get_sysroot() -> Result<PathBuf> {
+    let output = Command::new("rustc")
+        .arg("--print")
+        .arg("sysroot")
+        .output()?;
+
+    if !output.status.success() {
+        bail!(
+            "failed to execute `rustc --print sysroot`, \
+                 command exited with error: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let sysroot = PathBuf::from(String::from_utf8(output.stdout)?.trim());
+
+    Ok(sysroot)
+}


### PR DESCRIPTION
Implements #9 

This commit enables automatic installation of the wasm32-unknown-unknown target for the
`build` and `check` commands.

The installation will be performed if:

1. No `target` param is specified
2. The `wasm32-unknown-unknown` target is not already installed
3. `rustup` is available as the toolchain installer

---

This implementation is based on cargo-wasi's [`install_wasi_target`](https://github.com/bytecodealliance/cargo-wasi/blob/main/src/lib.rs#L237), with the difference that I'm not introducing a cache for the target check. 

I opted to leave the cache implementation up for discussion mainly because: (i) the cache can potentially introduce false positives if for example, the user removes the target manually after running `build` or `check` for the first time, so if we go ahead with the implementation we might need to think about an "eviction" mechanism analogous to `cargo wasi self clean` or think of a different caching approach (ii) cargo-wasi has several use-cases for the cache: one being the target installation and the other one being [update-checks](https://github.com/bytecodealliance/cargo-wasi/blob/main/src/internal.rs#L75), perhaps if update checks is something that we want to implement we could add the caching at that time? Right now we'd mostly be saving the `rustc --print sysroot` invocation.  Thoughts?