### PR TITLE
Add a `WASI Support` section to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ for linking components together, the usefulness of `cargo component`
 today is effectively limited to creating components that runtime
 and tooling developers can use to test their implementations.
 
+## WASI Support
+
+The current WASI preview does not yet support the WebAssembly component model.
+
+For that reason, `cargo component` currently targets `wasm32-unknown-unknown`
+by default.
+
+Once a WASI preview is available that supports the component model, `cargo component`
+will target WASI by default at that time.
+
 ## Installation
 
 To install the `cargo component` subcommand, first you'll want to install

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ The current WASI preview does not yet support the WebAssembly component model.
 For that reason, `cargo component` currently targets `wasm32-unknown-unknown`
 by default.
 
-Once a WASI preview is available that supports the component model, `cargo component`
+Once a WASI preview is available that [supports the component model][1], `cargo component`
 will target WASI by default at that time.
+
+[1]: https://github.com/WebAssembly/meetings/blob/main/wasi/2022/presentations/2022-06-30-gohman-wasi-preview2.pdf
 
 ## Installation
 


### PR DESCRIPTION
This PR adds a `WASI Support` section to the README to explain why `cargo
component` targets `wasm32-unknown-unknown` by default.

Closes #25.