### PR TITLE
Update `Cargo.toml` format for `cargo component`. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ The name of the crate is dependent upon the name specified in `Cargo.toml`:
 ```toml
 # ...
 
-[package.metadata.component.dependencies]
-interface = { path = "interface.wit", export = true }
+[package.metadata.component.exports]
+interface = "interface.wit"
 ```
 
 ## Usage
@@ -212,35 +212,35 @@ More commands will be added over time.
 
 ## Specifying Dependencies
 
-Component dependencies are interfaces defined in [wit](https://github.com/bytecodealliance/wit-bindgen)
-that are listed in a special section in the project's `Cargo.toml` file: 
+Dependencies are interfaces defined in [wit](https://github.com/bytecodealliance/wit-bindgen)
+that are listed in special sections in the project's `Cargo.toml` file.
+
+To import interfaces from your component, use the
+`[package.metadata.component.imports]` table.
+
+To export interfaces from your component, use the
+`[package.metadata.component.exports]` table.
+
+Dependencies are specified much like normal dependencies in `Cargo.toml`:
 
 ```toml
-[package.metadata.component.dependencies]
-```
-
-Dependencies are specified much like normal path dependencies in `Cargo.toml`:
-
-```toml
-binding-name = { version = "0.1.0", path = "path/to/interface.wit" }
-```
-
-By default, dependencies specified this way are for _imported_ interfaces.
-
-To specify an _exported_ interface, use the `export` key set to `true`:
-
-```toml
-binding-name = { version = "0.1.0", path = "path/to/interface.wit", export = true }
+binding-name = "path/to/interface.wit"
 ```
 
 To export a _default_ interface (i.e. one where the interface's functions
-are directly exported by the component itself), omit the `version` key:
+are directly exported by the component itself), set the `default` key to
+the name of the entry in the `[package.metadata.component.exports]` table.
 
 ```toml
-binding-name = { path = "path/to/interface.wit", export = true }
+[package.metadata.component]
+default = "foo"
 ```
 
-Only one _default_ interface may be specified.
+The `cargo component new` command generates a component project that initially
+only exports a default interface.
+
+Use the `cargo component add` command to easily add dependencies to your
+`Cargo.toml`.
 
 **Support for specifying version dependencies (e.g. `dep = "0.1.0"`) from a component registry will eventually be supported.**
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,7 +9,9 @@ crate-type = ["cdylib"]
 [dependencies]
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", default_features = false }
 
-[package.metadata.component.dependencies]
-cache = { version = "0.1.0", path = "cache.wit" }
-origin = { version = "0.1.0", path = "backend.wit" }
-backend = { version = "0.1.0", path = "backend.wit", export = true }
+[package.metadata.component.imports]
+cache = "cache.wit"
+origin = "backend.wit"
+
+[package.metadata.component.exports]
+backend = "backend.wit"

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -38,9 +38,9 @@ pub struct AddCommand {
     #[clap(long = "export")]
     pub export: bool,
 
-    /// Sets the dependency as the default interface (implies `--export`).
-    #[clap(long = "default")]
-    pub default: bool,
+    /// Sets the dependency as the directly exported interface (implies `--export`).
+    #[clap(long = "direct-export")]
+    pub direct_export: bool,
 
     /// Path to the manifest to add a dependency to
     #[clap(long = "manifest-path", value_name = "PATH")]
@@ -58,7 +58,7 @@ pub struct AddCommand {
 impl AddCommand {
     /// Executes the command
     pub fn exec(mut self, config: &mut Config) -> Result<()> {
-        if self.default {
+        if self.direct_export {
             self.export = true;
         }
 
@@ -121,8 +121,8 @@ impl AddCommand {
                 )
             })?;
 
-        if self.default {
-            component["default"] = value(&self.name);
+        if self.direct_export {
+            component["direct-interface-export"] = value(&self.name);
         }
 
         let deps = if self.export {
@@ -197,8 +197,8 @@ impl AddCommand {
             );
         }
 
-        if self.default && metadata.default.is_some() {
-            bail!("a default interface has already been specified in the manifest");
+        if self.direct_export && metadata.direct_export.is_some() {
+            bail!("a directly exported interface has already been specified in the manifest");
         }
 
         Ok(())

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use cargo::{core::package::Package, ops::Packages, Config};
 use clap::Args;
 use std::{fs, path::PathBuf};
-use toml_edit::{table, value, Document, InlineTable, Value};
+use toml_edit::{table, value, Document};
 
 /// Add a dependency for a WebAssembly component
 #[derive(Args)]
@@ -30,17 +30,17 @@ pub struct AddCommand {
     #[clap(long = "path", value_name = "PATH")]
     pub path: String,
 
-    /// Set the version of the dependency
-    #[clap(long = "version", value_name = "VERSION")]
-    pub version: Option<String>,
-
     /// Name of the dependency
     #[clap(value_name = "name")]
     pub name: String,
 
-    /// Set the dependency as an exported interface
+    /// Add the dependency as an exported interface
     #[clap(long = "export")]
     pub export: bool,
+
+    /// Sets the dependency as the default interface (implies `--export`).
+    #[clap(long = "default")]
+    pub default: bool,
 
     /// Path to the manifest to add a dependency to
     #[clap(long = "manifest-path", value_name = "PATH")]
@@ -57,7 +57,11 @@ pub struct AddCommand {
 
 impl AddCommand {
     /// Executes the command
-    pub fn exec(self, config: &mut Config) -> Result<()> {
+    pub fn exec(mut self, config: &mut Config) -> Result<()> {
+        if self.default {
+            self.export = true;
+        }
+
         config.configure(
             self.verbose,
             self.quiet,
@@ -73,25 +77,24 @@ impl AddCommand {
         let ws = workspace(self.manifest_path.as_deref(), config)?;
         let package = if let Some(ref inner) = self.package {
             let pkg = Packages::from_flags(false, vec![], vec![inner.clone()])?;
-            let packages = pkg.get_packages(&ws)?;
-
-            packages[0]
+            pkg.get_packages(&ws)?[0]
         } else {
             ws.current()?
         };
 
         let component_metadata = ComponentMetadata::from_package(config, package)?;
 
-        self.validate(&component_metadata)
-            .and_then(|_| self.add(package))?;
+        self.validate(package, &component_metadata)?;
+        self.add(package)?;
 
-        let status = if let Some(v) = self.version {
-            format!("interface {} v{} to dependencies", self.name, v)
-        } else {
-            format!("interface {} to dependencies", self.name)
-        };
-
-        config.shell().status("Adding", status)?;
+        config.shell().status(
+            "Adding",
+            format!(
+                "interface {name} to {ty}",
+                name = self.name,
+                ty = if self.export { "exports" } else { "imports" }
+            ),
+        )?;
 
         Ok(())
     }
@@ -104,8 +107,8 @@ impl AddCommand {
 
         let mut document: Document = manifest.parse().with_context(|| {
             format!(
-                "failed to parse manifest file `{}`",
-                manifest_path.display()
+                "failed to parse manifest file `{path}`",
+                path = manifest_path.display()
             )
         })?;
 
@@ -113,31 +116,30 @@ impl AddCommand {
             .as_table_mut()
             .with_context(|| {
                 format!(
-                    "failed to find component metadata in manifest file `{}`",
-                    manifest_path.display()
+                    "failed to find component metadata in manifest file `{path}`",
+                    path = manifest_path.display()
                 )
             })?;
 
-        let deps = component.entry("dependencies").or_insert(table());
-        let mut inline_table = vec![("path", Value::from(self.path.clone()))];
-
-        if let Some(v) = &self.version {
-            inline_table.push(("version", Value::from(v.clone())));
+        if self.default {
+            component["default"] = value(&self.name);
         }
 
-        if self.export {
-            inline_table.push(("export", Value::from(true)));
-        }
+        let deps = if self.export {
+            component.entry("exports").or_insert_with(table)
+        } else {
+            component.entry("imports").or_insert_with(table)
+        };
 
-        deps[&self.name] = value(InlineTable::from_iter(inline_table));
+        deps[&self.name] = value(&self.path);
 
         if self.dry_run {
             println!("{}", document);
         } else {
             fs::write(&manifest_path, document.to_string()).with_context(|| {
                 format!(
-                    "failed to write manifest file `{}`",
-                    manifest_path.display()
+                    "failed to write manifest file `{path}`",
+                    path = manifest_path.display()
                 )
             })?;
         }
@@ -145,44 +147,58 @@ impl AddCommand {
         Ok(())
     }
 
-    fn validate(&self, metadata: &ComponentMetadata) -> Result<()> {
-        let path = PathBuf::from(&self.path);
-        if !path.exists() {
-            bail!("interface file `{}` does not exist", path.display());
+    fn validate(&self, package: &Package, metadata: &ComponentMetadata) -> Result<()> {
+        if package.name() == self.name.as_str() {
+            bail!(
+                "cannot add dependency `{name}` as it conflicts with the package name",
+                name = self.name
+            );
         }
 
-        if self.export {
-            // Validate default export
-            if let Some(default) = &metadata.interface {
-                if self.version.is_none() || self.name == default.interface.name {
-                    bail!(
-                        "dependency `{}` already exists as the default interface",
-                        default.interface.name
-                    );
-                }
-            }
-        } else if self.version.is_none() {
-            bail!("version not specified for import `{}`", self.name);
-        }
-
-        // Validate exports
-        let export = metadata
-            .exports
+        if package
+            .manifest()
+            .dependencies()
             .iter()
-            .find(|e| self.name == e.interface.name);
-
-        if export.is_some() {
-            bail!("dependency `{}` already exists as an export", self.name);
+            .any(|d| d.name_in_toml() == self.name.as_str())
+        {
+            bail!(
+                "a crate dependency with name `{name}` already exists",
+                name = self.name,
+            );
         }
 
-        // Validate imports
-        let import = metadata
+        if metadata
             .imports
             .iter()
-            .find(|i| i.interface.name == self.name);
+            .any(|d| d.interface.name == self.name)
+        {
+            bail!(
+                "an import with name `{name}` already exists",
+                name = self.name,
+            );
+        }
 
-        if import.is_some() {
-            bail!("dependency `{}` already exists as an import", self.name);
+        if metadata
+            .exports
+            .iter()
+            .any(|d| d.interface.name == self.name)
+        {
+            bail!(
+                "an export with name `{name}` already exists",
+                name = self.name,
+            );
+        }
+
+        let path = PathBuf::from(&self.path);
+        if !path.exists() {
+            bail!(
+                "interface file `{path}` does not exist or is not a file",
+                path = path.display()
+            );
+        }
+
+        if self.default && metadata.default.is_some() {
+            bail!("a default interface has already been specified in the manifest");
         }
 
         Ok(())

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -146,20 +146,13 @@ impl NewCommand {
         doc["lib"] = table();
         doc["lib"]["crate-type"] = value(Value::from_iter(["cdylib"].into_iter()));
 
-        let interface = InlineTable::from_iter(
-            [
-                ("path", Value::from("interface.wit")),
-                ("export", Value::from(true)),
-            ]
-            .into_iter(),
-        );
-
-        let mut dependencies = Table::new();
-        dependencies["interface"] = Item::Value(Value::InlineTable(interface));
+        let mut exports = Table::new();
+        exports["interface"] = value("interface.wit");
 
         let mut component = Table::new();
         component.set_implicit(true);
-        component["dependencies"] = Item::Table(dependencies);
+        component["default"] = value("interface");
+        component["exports"] = Item::Table(exports);
 
         let mut metadata = Table::new();
         metadata.set_implicit(true);

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -151,7 +151,7 @@ impl NewCommand {
 
         let mut component = Table::new();
         component.set_implicit(true);
-        component["default"] = value("interface");
+        component["direct-interface-export"] = value("interface");
         component["exports"] = Item::Table(exports);
 
         let mut metadata = Table::new();

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -57,10 +57,10 @@ fn checks_for_duplicate_exports() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --path interface.wit --default export")
+        .cargo_component("add --path interface.wit --direct-export export")
         .assert()
         .stderr(contains(
-            "a default interface has already been specified in the manifest",
+            "a directly exported interface has already been specified in the manifest",
         ))
         .failure();
 

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -25,12 +25,28 @@ fn requires_path_and_name() {
 }
 
 #[test]
-fn validate_the_interface_file_exists() -> Result<()> {
+fn validate_name_does_not_conflict_with_package() -> Result<()> {
     let project = Project::new("foo")?;
     project
         .cargo_component("add --path foo.wit foo")
         .assert()
-        .stderr(contains("interface file `foo.wit` does not exist"))
+        .stderr(contains(
+            "cannot add dependency `foo` as it conflicts with the package name",
+        ))
+        .failure();
+
+    Ok(())
+}
+
+#[test]
+fn validate_the_interface_file_exists() -> Result<()> {
+    let project = Project::new("foo")?;
+    project
+        .cargo_component("add --path bar.wit bar")
+        .assert()
+        .stderr(contains(
+            "interface file `bar.wit` does not exist or is not a file",
+        ))
         .failure();
 
     Ok(())
@@ -41,22 +57,33 @@ fn checks_for_duplicate_exports() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --path interface.wit --export export")
+        .cargo_component("add --path interface.wit --default export")
         .assert()
         .stderr(contains(
-            "dependency `interface` already exists as the default interface",
+            "a default interface has already been specified in the manifest",
         ))
         .failure();
 
     project
-        .cargo_component("add --path interface.wit --version 0.1.0 --export export")
+        .cargo_component("add --path interface.wit --export export")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit --version 0.1.0 --export export")
+        .cargo_component("add --path interface.wit import")
         .assert()
-        .stderr(contains("dependency `export` already exists as an export"))
+        .success();
+
+    project
+        .cargo_component("add --path interface.wit --export export")
+        .assert()
+        .stderr(contains("an export with name `export` already exists"))
+        .failure();
+
+    project
+        .cargo_component("add --path interface.wit --export import")
+        .assert()
+        .stderr(contains("an import with name `import` already exists"))
         .failure();
 
     Ok(())
@@ -69,18 +96,23 @@ fn checks_for_duplicate_imports() -> Result<()> {
     project
         .cargo_component("add --path interface.wit import")
         .assert()
-        .stderr(contains("version not specified for import"))
-        .failure();
+        .success();
 
     project
-        .cargo_component("add --path interface.wit --version 0.1.0 import")
+        .cargo_component("add --path interface.wit --export export")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit --version 0.1.0 import")
+        .cargo_component("add --path interface.wit import")
         .assert()
-        .stderr(contains("dependency `import` already exists as an import"))
+        .stderr(contains("an import with name `import` already exists"))
+        .failure();
+
+    project
+        .cargo_component("add --path interface.wit export")
+        .assert()
+        .stderr(contains("an export with name `export` already exists"))
         .failure();
 
     Ok(())
@@ -91,11 +123,9 @@ fn prints_modified_manifest_for_dry_run() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --dry-run --path interface.wit --version 0.8.0 import")
+        .cargo_component("add --dry-run --path interface.wit import")
         .assert()
-        .stdout(contains(
-            r#"import = { path = "interface.wit", version = "0.8.0" }"#,
-        ))
+        .stdout(contains(r#"import = "interface.wit""#))
         .success();
 
     // Assert the dependency was not added to the manifest


### PR DESCRIPTION
This PR updates the format for `Cargo.toml` to make it clearer as to what
gets imported and what gets exported.

It splits the former `dependencies` table into two tables `imports` and
`exports`.

Each dependency in those tables is uniformly specified as either:

```toml
dep = "path"
```

or:

```toml
dep = { path = "path" }
```

This removes the version numbers from the dependencies for now until such time
as they are useful.

A warning was added if we encounter the old `dependencies` table to warn users
they need to upgrade their `Cargo.toml` format; the tool doesn't attempt to do
so automatically (sorry).

Closes #28.