### PR TITLE
Bump dependencies to latest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "arrayvec"
@@ -227,9 +227,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.15"
+version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
 dependencies = [
  "atty",
  "bitflags",
@@ -1593,7 +1593,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 [[package]]
 name = "wit-bindgen-gen-core"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=005a9e6d#005a9e6d5befe4652c0e6e05578b245ab96b3cea"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=f7f95ba#f7f95bacfac69c1cd05832afda255eff959cb178"
 dependencies = [
  "anyhow",
  "wit-parser",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=005a9e6d#005a9e6d5befe4652c0e6e05578b245ab96b3cea"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=f7f95ba#f7f95bacfac69c1cd05832afda255eff959cb178"
 dependencies = [
  "heck 0.3.3",
  "wit-bindgen-gen-core",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-wasm"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=005a9e6d#005a9e6d5befe4652c0e6e05578b245ab96b3cea"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=f7f95ba#f7f95bacfac69c1cd05832afda255eff959cb178"
 dependencies = [
  "heck 0.3.3",
  "wit-bindgen-gen-core",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=005a9e6d#005a9e6d5befe4652c0e6e05578b245ab96b3cea"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=f7f95ba#f7f95bacfac69c1cd05832afda255eff959cb178"
 dependencies = [
  "anyhow",
  "clap",
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=005a9e6d#005a9e6d5befe4652c0e6e05578b245ab96b3cea"
+source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=f7f95ba#f7f95bacfac69c1cd05832afda255eff959cb178"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.58"
+anyhow = "1.0.59"
 cargo = "0.63.1"
 cargo-util = "0.2.0"
-clap = { version = "3.2.15", features = ["derive"] }
+clap = { version = "3.2.16", features = ["derive"] }
 toml_edit = { version = "0.14.4", features = ["easy"] }
-wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "005a9e6d" }
-wit-bindgen-gen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "005a9e6d" }
-wit-bindgen-gen-rust-wasm = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "005a9e6d" }
-wit-component = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "005a9e6d" }
+wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "f7f95ba" }
+wit-bindgen-gen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "f7f95ba" }
+wit-bindgen-gen-rust-wasm = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "f7f95ba" }
+wit-component = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "f7f95ba" }
 pretty_env_logger = { version = "0.4.0", optional = true }
 log = "0.4.17"
 


### PR DESCRIPTION
This PR bumps `cargo-component` dependencies to latest.

It includes updating `wit-bindgen` for the latest binding fixes.