### PR TITLE
chore: upgrade to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "bytesize",
  "cargo-platform",
  "cargo-util",
- "clap",
+ "clap 3.2.22",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -167,7 +167,7 @@ dependencies = [
  "assert_cmd",
  "cargo",
  "cargo-util",
- "clap",
+ "clap 4.0.12",
  "log",
  "predicates",
  "pretty_env_logger",
@@ -233,13 +233,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.2",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385007cbbed899260395a4107435fead4cad80684461b3cc78238bdcb0bad58f"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.10",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -256,10 +271,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1023,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1616,7 +1653,7 @@ version = "0.2.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=5e90ee0#5e90ee021f2c06d2a788c63778d81254dd311e6d"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 3.2.22",
  "env_logger 0.9.1",
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.65"
 cargo = "0.65.0"
 cargo-util = "0.2.1"
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.12", features = ["derive"] }
 toml_edit = { version = "0.14.4", features = ["easy"] }
 wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "5e90ee0" }
 wit-bindgen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "5e90ee0" }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -2,7 +2,7 @@ use super::workspace;
 use crate::ComponentMetadata;
 use anyhow::{bail, Context, Result};
 use cargo::{core::package::Package, ops::Packages, Config};
-use clap::Args;
+use clap::{ArgAction, Args};
 use std::{fs, path::PathBuf};
 use toml_edit::{table, value, Document};
 
@@ -17,10 +17,9 @@ pub struct AddCommand {
     #[clap(
         long = "verbose",
         short = 'v',
-        takes_value = false,
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
-    pub verbose: u32,
+    pub verbose: u8,
 
     /// Coloring: auto, always, never
     #[clap(long = "color", value_name = "WHEN")]
@@ -63,7 +62,7 @@ impl AddCommand {
         }
 
         config.configure(
-            self.verbose,
+            u32::from(self.verbose),
             self.quiet,
             self.color.as_deref(),
             false,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,7 +1,7 @@
 use crate::commands::{workspace, CompileOptions};
 use anyhow::Result;
 use cargo::{core::compiler::CompileMode, Config};
-use clap::Args;
+use clap::{ArgAction, Args};
 use std::path::PathBuf;
 
 /// Compile a WebAssembly component and all of its dependencies
@@ -67,10 +67,9 @@ pub struct BuildCommand {
     #[clap(
         long = "verbose",
         short = 'v',
-        takes_value = false,
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
-    pub verbose: u32,
+    pub verbose: u8,
 
     /// Coloring: auto, always, never
     #[clap(long = "color", value_name = "WHEN")]
@@ -111,7 +110,7 @@ impl BuildCommand {
         log::debug!("executing compile command");
 
         config.configure(
-            self.verbose,
+            u32::from(self.verbose),
             self.quiet,
             self.color.as_deref(),
             self.frozen,

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,7 +1,7 @@
 use crate::commands::{workspace, CompileOptions};
 use anyhow::Result;
 use cargo::{core::compiler::CompileMode, Config};
-use clap::Args;
+use clap::{ArgAction, Args};
 use std::path::PathBuf;
 
 /// Check a local package and all of its dependencies for errors
@@ -27,10 +27,9 @@ pub struct CheckCommand {
     #[clap(
         long = "verbose",
         short = 'v',
-        takes_value = false,
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
-    pub verbose: u32,
+    pub verbose: u8,
 
     /// Coloring: auto, always, never
     #[clap(long = "color", value_name = "WHEN")]
@@ -111,7 +110,7 @@ impl CheckCommand {
         log::debug!("executing metadata command");
 
         config.configure(
-            self.verbose,
+            u32::from(self.verbose),
             self.quiet,
             self.color.as_deref(),
             self.frozen,

--- a/src/commands/clippy.rs
+++ b/src/commands/clippy.rs
@@ -43,7 +43,7 @@ impl ClippyCommand {
         log::debug!("executing clippy command");
 
         config.configure(
-            self.options.verbose,
+            u32::from(self.options.verbose),
             self.options.quiet,
             self.options.color.as_deref(),
             self.options.frozen,

--- a/src/commands/metadata.rs
+++ b/src/commands/metadata.rs
@@ -1,7 +1,7 @@
 use crate::{commands::workspace, metadata};
 use anyhow::Result;
 use cargo::{core::resolver::CliFeatures, ops::OutputMetadataOptions, Config};
-use clap::Args;
+use clap::{value_parser, ArgAction, Args};
 use std::path::PathBuf;
 
 /// Output the resolved dependencies of a package, the concrete used versions
@@ -32,10 +32,9 @@ pub struct MetadataCommand {
     #[clap(
         long = "verbose",
         short = 'v',
-        takes_value = false,
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
-    pub verbose: u32,
+    pub verbose: u8,
 
     /// Coloring: auto, always, never
     #[clap(long = "color", value_name = "WHEN")]
@@ -54,7 +53,11 @@ pub struct MetadataCommand {
     pub manifest_path: Option<PathBuf>,
 
     /// Format version
-    #[clap(long = "format-version", value_name = "VERSION", possible_values = ["1"])]
+    #[clap(
+        long = "format-version",
+        value_name = "VERSION",
+        value_parser = value_parser!(u32).range(1..=1)
+    )]
     pub format_version: Option<u32>,
 
     /// Require Cargo.lock is up to date
@@ -76,7 +79,7 @@ impl MetadataCommand {
         log::debug!("executing metadata command");
 
         config.configure(
-            self.verbose,
+            u32::from(self.verbose),
             self.quiet,
             self.color.as_deref(),
             self.frozen,

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -3,7 +3,7 @@ use cargo::{
     ops::{self, NewOptions, VersionControl},
     Config,
 };
-use clap::Args;
+use clap::{ArgAction, Args};
 use std::{fs, path::Path};
 use toml_edit::{table, value, Document, InlineTable, Item, Table, Value};
 
@@ -20,17 +20,16 @@ pub struct NewCommand {
     /// control system (git, hg, pijul, or fossil) or do not
     /// initialize any version control at all (none), overriding
     /// a global configuration.
-    #[clap(long = "vcs", value_name = "VCS", possible_values = ["git", "hg", "pijul", "fossil", "none"])]
+    #[clap(long = "vcs", value_name = "VCS", value_parser = ["git", "hg", "pijul", "fossil", "none"])]
     pub vcs: Option<String>,
 
     /// Use verbose output (-vv very verbose/build.rs output)
     #[clap(
         long = "verbose",
         short = 'v',
-        takes_value = false,
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
-    pub verbose: u32,
+    pub verbose: u8,
 
     ///  Use a library template [default]
     #[clap(long = "lib")]
@@ -41,7 +40,7 @@ pub struct NewCommand {
     pub color: Option<String>,
 
     /// Edition to set for the generated crate
-    #[clap(long = "edition", value_name = "YEAR", possible_values = ["2015", "2018", "2021"])]
+    #[clap(long = "edition", value_name = "YEAR", value_parser = ["2015", "2018", "2021"])]
     pub edition: Option<String>,
 
     /// Require Cargo.lock and cache are up to date
@@ -61,7 +60,7 @@ pub struct NewCommand {
     pub offline: bool,
 
     /// Code editor to use for rust-analyzer integration, defaults to `vscode`
-    #[clap(long = "editor", value_name = "EDITOR", possible_values = ["vscode", "none"])]
+    #[clap(long = "editor", value_name = "EDITOR", value_parser = ["vscode", "none"])]
     pub editor: Option<String>,
 
     /// The path for the generated package.
@@ -75,7 +74,7 @@ impl NewCommand {
         log::debug!("executing new command");
 
         config.configure(
-            self.verbose,
+            u32::from(self.verbose),
             self.quiet,
             self.color.as_deref(),
             self.frozen,

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -27,3 +27,18 @@ fn it_prints_metadata() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn it_rejects_invalid_format_versions() -> Result<()> {
+    let project = Project::new("foo")?;
+
+    for arg in ["bad", "1.42", "0", "42"] {
+        project
+            .cargo_component(format!("metadata --format-version {}", arg).as_str())
+            .assert()
+            .stderr(contains("Invalid value"))
+            .failure();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Upstream cargo has [upgraded](https://github.com/rust-lang/cargo/blob/master/Cargo.toml#L65) to clap v4.

`takes_value` has been deprecated.
`num_args` (the replacement for `takes_value`) will default `num_args` based on the `ArgAction` and doesn't need to be set for the verbose flag use-case. But there's one more change. Commands with ArgAction::Count must be u8.

Test caught this:

```bash
command=`"/Users/bhayes/repos/bytecodealliance/cargo-component/target/debug/cargo-component" "component" "add"`
code=101
stdout=""
stderr="thread \'main\' panicked at \'assertion failed: `(left == right)`\n  left: `u8`,\n right: `u32`: Argument `verbose`\'s selected action Count contradicts `value_parser` (ValueParser::other(u32))\', /Users/bhayes/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.12/src/builder/debug_asserts.rs:708:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"
', /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/ops/function.rs:248:5

---- help stdout ----
thread 'help' panicked at 'Unexpected stdout, failed var.contains(Add a dependency for a WebAssembly component)
├── var:
└── var as str:

command=`"/Users/bhayes/repos/bytecodealliance/cargo-component/target/debug/cargo-component" "component" "help" "add"`
code=101
stdout=""
stderr="thread \'main\' panicked at \'assertion failed: `(left == right)`\n  left: `u8`,\n right: `u32`: Argument `verbose`\'s selected action Count contradicts `value_parser` (ValueParser::other(u32))\', /Users/bhayes/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.12/src/builder/debug_asserts.rs:708:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"
', /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/ops/function.rs:248:5
```

`Arg::possible_values` has been replaced with `Arg::value_parser([...])`. Things got a little awkward here. While upstream cargo seems to be able to pass in `value_parser = ["1"]` ([src](https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/commands/metadata.rs#L27)), we get a downcast error.

```bash
stderr="thread \'main\' panicked at \'Mismatch between definition and access of `format_version`. Could not downcast to u32, need to downcast to alloc::string::String\n\', src/commands/metadata.rs:62:25\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n"
```

Kudos on solid test coverage.
The tests caught all of these after the build succeeded. I added an additional test around format-version.