### PR TITLE
Implement support for workspaces. 

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -81,7 +81,13 @@ impl AddCommand {
             ws.current()?
         };
 
-        let component_metadata = ComponentMetadata::from_package(config, package)?;
+        let component_metadata = match ComponentMetadata::from_package(config, package)? {
+            Some(metadata) => metadata,
+            None => bail!(
+                "manifest `{path}` is not a WebAssembly component package",
+                path = package.manifest_path().display(),
+            ),
+        };
 
         self.validate(package, &component_metadata)?;
         self.add(package)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,14 +143,6 @@ impl ComponentMetadata {
             )
         })?;
 
-        // Warn if there's a legacy `dependencies` section for now
-        if component.get("dependencies").is_some() {
-            config.shell().warn(format!(
-                "manifest `{path}` contains a `{COMPONENT_SECTION_PATH}.dependencies` section and needs to be upgraded",
-                path = manifest_path.display(),
-            ))?;
-        }
-
         let imports = Self::read_dependencies(
             manifest_path,
             config,

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -24,7 +24,7 @@ fn it_checks_a_new_project() -> Result<()> {
     project
         .cargo_component("check")
         .assert()
-        .stderr(contains("Checking interface v0.1.0"))
+        .stderr(contains("Checking foo-interface v0.1.0"))
         .success();
 
     Ok(())
@@ -43,10 +43,53 @@ fn it_finds_errors() -> Result<()> {
         .cargo_component("check")
         .assert()
         .stderr(
-            contains("Checking interface v0.1.0")
+            contains("Checking foo-interface v0.1.0")
                 .and(contains("expected struct `String`, found `&str`")),
         )
         .failure();
+
+    Ok(())
+}
+
+#[test]
+fn it_checks_a_workspace() -> Result<()> {
+    let project = project()?
+        .file(
+            "Cargo.toml",
+            r#"[workspace]
+members = ["foo", "bar", "baz"]
+"#,
+        )?
+        .file(
+            "baz/Cargo.toml",
+            r#"[package]
+name = "baz"
+version = "0.1.0"
+edition = "2021"
+    
+[dependencies]
+"#,
+        )?
+        .file("baz/src/lib.rs", "")?
+        .build()?;
+
+    project
+        .cargo_component("new foo")
+        .assert()
+        .stderr(contains("Created component `foo` package"))
+        .success();
+
+    project
+        .cargo_component("new bar")
+        .assert()
+        .stderr(contains("Created component `bar` package"))
+        .success();
+
+    project
+        .cargo_component("check")
+        .assert()
+        .stderr(contains("Finished dev [unoptimized + debuginfo] target(s)"))
+        .success();
 
     Ok(())
 }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -80,7 +80,10 @@ edition = "2021"
     project
         .cargo_component("metadata --format-version 1")
         .assert()
-        .stdout(contains("foo-interface 0.1.0").and(contains("bar-interface 0.1.0")))
+        .stdout(
+            contains("foo-interface 0.1.0")
+                .and(contains("bar-interface 0.1.0").and(contains("baz 0.1.0"))),
+        )
         .success();
 
     Ok(())


### PR DESCRIPTION
This PR implements support for handling workspaces and not individual
component packages.

`cargo-component` now scans the set of packages in the workspace for packages
with component metadata, generates bindings for only those packages, and then
also generates components only for those packages (for the build command).

Fixes https://github.com/bytecodealliance/cargo-component/issues/34.