### PR TITLE
Update cargo-component dependencies to latest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bytesize"
@@ -177,12 +177,13 @@ dependencies = [
  "assert_cmd",
  "cargo",
  "cargo-util",
- "clap 4.0.23",
+ "clap 4.0.26",
+ "heck",
  "log",
  "predicates",
  "pretty_env_logger",
  "toml_edit",
- "wasmparser 0.94.0",
+ "wasmparser",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
  "wit-component",
@@ -222,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -252,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
@@ -365,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -696,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -886,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -918,9 +919,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -942,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pathdiff"
@@ -1202,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -1477,59 +1478,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64ac98d5d61192cc45c701b7e4bd0b9aff91e2edfc7a088406cfe2288581e2c"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.92.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
 dependencies = [
  "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdac7e1d98d70913ae3b4923dd7419c8ea7bdfd4c44a240a0ba305d929b7f191"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
-name = "wast"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ef81fcd60d244cafffeafac3d17615fdb2fddda6aca18f34a8ae233353587c"
-dependencies = [
- "leb128",
- "memchr",
- "unicode-width",
- "wasm-encoder 0.19.1",
-]
-
-[[package]]
-name = "wat"
-version = "1.0.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c347c4460ffb311e95aafccd8c29e4888f241b9e4b3bb0e0ccbd998de2c8c0d"
-dependencies = [
- "wast",
+ "url",
 ]
 
 [[package]]
@@ -1666,7 +1629,7 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 [[package]]
 name = "wit-bindgen-core"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=bd89607#bd896073bd708a5f5e2780b63eecdca30b6438b4"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#4bd4371084c9fe57ae236238386d8a5f91217b50"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1676,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=bd89607#bd896073bd708a5f5e2780b63eecdca30b6438b4"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#4bd4371084c9fe57ae236238386d8a5f91217b50"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1687,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-lib"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=bd89607#bd896073bd708a5f5e2780b63eecdca30b6438b4"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#4bd4371084c9fe57ae236238386d8a5f91217b50"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1695,28 +1658,28 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=bd89607#bd896073bd708a5f5e2780b63eecdca30b6438b4"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a4db4b7de170ce349e2575f305ad592623ce16cbe824344894a10e60ab879"
 dependencies = [
  "anyhow",
  "bitflags",
- "clap 4.0.23",
- "env_logger 0.9.3",
  "indexmap",
  "log",
- "wasm-encoder 0.18.0",
- "wasmparser 0.92.0",
- "wat",
+ "wasm-encoder",
+ "wasmparser",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?rev=bd89607#bd896073bd708a5f5e2780b63eecdca30b6438b4"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703eb1d2f89ff2c52d50f7ff002735e423cea75f0a5dc5c8a4626c4c47cd9ca6"
 dependencies = [
  "anyhow",
  "id-arena",
+ "indexmap",
  "pulldown-cmark",
  "unicode-xid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,15 @@ edition = "2021"
 anyhow = "1.0.66"
 cargo = "0.66.0"
 cargo-util = "0.2.2"
-clap = { version = "4.0.23", features = ["derive"] }
+clap = { version = "4.0.26", features = ["derive"] }
 toml_edit = { version = "0.14.4", features = ["easy"] }
-wit-parser = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "bd89607" }
-wit-bindgen-core = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "bd89607" }
-wit-bindgen-gen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "bd89607" }
-wit-component = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "bd89607" }
+wit-bindgen-core = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-gen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-parser = "0.3.1"
+wit-component = "0.3.2"
 pretty_env_logger = { version = "0.4.0", optional = true }
 log = "0.4.17"
+heck = "0.4.0"
 
 [features]
 default = ["pretty_env_logger"]
@@ -22,4 +23,4 @@ default = ["pretty_env_logger"]
 [dev-dependencies]
 assert_cmd = "2.0.6"
 predicates = "2.1.3"
-wasmparser = "0.94.0"
+wasmparser = "0.95.0"

--- a/README.md
+++ b/README.md
@@ -165,26 +165,28 @@ updated to install the crates.io package once a proper release is made.
 
 ## Getting Started
 
-Use `cargo component new` to create a simple "hello world" style component.
+Use `cargo component new <name>` to create a new component.
 
-This will generate an `interface.wit` file that describes the component's
-directly exported interface:
+Assuming you used the name `hello` for your component, it will create a `./hello.wit`
+file describing the component's directly-exported interface:
 
 ```wit
-say-something: func() -> string
+interface hello {
+  hello-world: func() -> string
+}
 ```
 
-The component will export a `say-something` function returning a string.
+The component will export a `hello-world` function returning a string.
 
 The implementation of the component will be in `src/lib.rs`:
 
 ```rust
-use bindings::interface;
+use bindings::hello;
 
 struct Component;
 
-impl interface::Interface for Component {
-    fn say_something() -> String {
+impl hello::Hello for Component {
+    fn hello_world() -> String {
         "Hello, World!".to_string()
     }
 }
@@ -192,19 +194,23 @@ impl interface::Interface for Component {
 bindings::export!(Component);
 ```
 
-Here `interface` is the bindings crate that `cargo component` generated for you.
+Here `bindings` is the bindings crate that `cargo component` generated for you.
 
-The `export!` macro informs the bindings that the `Component` type implements
-the interface.
+The `export!` macro informs the bindings that the `Component` type exports
+all interfaces listed in `Cargo.toml`.
 
-The name of the crate is dependent upon the name specified in `Cargo.toml`:
+The name of each binding sub-module is dependent upon the names specified in
+`Cargo.toml`:
 
 ```toml
 # ...
 
 [package.metadata.component.exports]
-interface = "interface.wit"
+hello = "hello.wit"
 ```
+
+This will generate a `bindings::hello` module that contains the `Hello` trait
+implemented by the component above.
 
 ## Usage
 

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#064bd1a79342a51ab1ed5c0ea30674eda6773f5e"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#4bd4371084c9fe57ae236238386d8a5f91217b50"
 dependencies = [
  "bitflags",
 ]

--- a/example/backend.wit
+++ b/example/backend.wit
@@ -1,2 +1,5 @@
-/// Fetch the content bytes of the given URL.
-fetch: func(url: string) -> list<u8>
+/// An example backend interface.
+interface backend {
+    /// Fetch the content bytes of the given URL.
+    fetch: func(url: string) -> list<u8>
+}

--- a/example/cache.wit
+++ b/example/cache.wit
@@ -1,5 +1,8 @@
-/// Get a value from the cache.
-get: func(key: string) -> option<list<u8>>
+/// An example cache interface.
+interface cache {
+    /// Get a value from the cache.
+    get: func(key: string) -> option<list<u8>>
 
-/// Put a value into the cache.
-put: func(key: string, value: list<u8>)
+    /// Put a value into the cache.
+    put: func(key: string, value: list<u8>)
+}

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,10 +1,15 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use cargo::{
     ops::{self, NewOptions, VersionControl},
     Config,
 };
 use clap::{ArgAction, Args};
-use std::{fs, path::Path};
+use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
+use std::{
+    borrow::Cow,
+    fmt, fs,
+    path::{Path, PathBuf},
+};
 use toml_edit::{table, value, Document, InlineTable, Item, Table, Value};
 
 use crate::WIT_BINDGEN_REPO;
@@ -65,13 +70,169 @@ pub struct NewCommand {
 
     /// The path for the generated package.
     #[clap(value_name = "path")]
-    pub path: String,
+    pub path: PathBuf,
+}
+
+struct PackageName<'a> {
+    display: Cow<'a, str>,
+    kebab: String,
+    snake: String,
+    camel: String,
+}
+
+impl<'a> PackageName<'a> {
+    fn new(name: Option<&'a str>, path: &'a Path) -> Result<Self> {
+        let (package, display) = match name {
+            Some(name) => (name.into(), name.into()),
+            None => (
+                path.file_name().expect("invalid path").to_string_lossy(),
+                // `cargo new` prints the given path to the new package, so
+                // use the path for the display value.
+                path.as_os_str().to_string_lossy(),
+            ),
+        };
+
+        let kebab = package.to_kebab_case();
+        let snake = package.to_snake_case();
+        let camel = package.to_upper_camel_case();
+
+        if kebab.is_empty() || snake.is_empty() || camel.is_empty() {
+            bail!("invalid component name `{package}`");
+        }
+
+        wit_parser::validate_id(&kebab)
+            .with_context(|| format!("component name `{package}` is not a legal WIT identifier"))?;
+
+        if Self::is_wit_keyword(&kebab) {
+            bail!("component name `{package}` cannot be used as it is a WIT keyword");
+        }
+
+        if Self::is_rust_keyword(&snake) {
+            bail!("component name `{package}` cannot be used as it is a Rust keyword");
+        }
+
+        Ok(Self {
+            display,
+            kebab,
+            snake,
+            camel,
+        })
+    }
+
+    fn is_wit_keyword(s: &str) -> bool {
+        // TODO: move this into wit-parser?
+        matches!(
+            s,
+            "use"
+                | "type"
+                | "func"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "s8"
+                | "s16"
+                | "s32"
+                | "s64"
+                | "float32"
+                | "float64"
+                | "char"
+                | "record"
+                | "list"
+                | "flags"
+                | "variant"
+                | "enum"
+                | "union"
+                | "bool"
+                | "string"
+                | "option"
+                | "result"
+                | "future"
+                | "stream"
+                | "as"
+                | "from"
+                | "static"
+                | "interface"
+                | "tuple"
+                | "implements"
+                | "import"
+                | "export"
+                | "world"
+                | "default"
+        )
+    }
+
+    fn is_rust_keyword(s: &str) -> bool {
+        // TODO: source this from somewhere?
+        matches!(
+            s,
+            "as" 
+                | "async"
+                | "await"
+                | "break"
+                | "const"
+                | "continue"
+                | "crate"
+                | "dyn"
+                | "else"
+                | "enum"
+                | "extern"
+                | "false"
+                | "fn"
+                | "for"
+                | "if"
+                | "impl"
+                | "in"
+                | "let"
+                | "loop"
+                | "match"
+                | "mod"
+                | "move"
+                | "mut"
+                | "pub"
+                | "ref"
+                | "return"
+                | "self"
+                | "static"
+                | "struct"
+                | "super"
+                | "trait"
+                | "true"
+                | "type"
+                | "unsafe"
+                | "use"
+                | "where"
+                | "while"
+                // Reserved for future use
+                | "abstract"
+                | "become"
+                | "box"
+                | "do"
+                | "final"
+                | "macro"
+                | "override"
+                | "priv"
+                | "try"
+                | "typeof"
+                | "unsized"
+                | "virtual"
+                | "yield"
+        )
+    }
+}
+
+impl fmt::Display for PackageName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.display)
+    }
 }
 
 impl NewCommand {
     /// Executes the command.
     pub fn exec(self, config: &mut Config) -> Result<()> {
         log::debug!("executing new command");
+
+        let name = PackageName::new(self.name.as_deref(), &self.path)?;
 
         config.configure(
             u32::from(self.verbose),
@@ -90,20 +251,16 @@ impl NewCommand {
         ops::new(&opts, config)?;
 
         let out_dir = config.cwd().join(&self.path);
-        self.update_manifest(&out_dir)?;
-        self.update_source_file(&out_dir)?;
-        self.create_interface_file(&out_dir)?;
+        self.update_manifest(&name, &out_dir)?;
+        self.update_source_file(&name, &out_dir)?;
+        self.create_interface_file(&name, &out_dir)?;
         self.create_editor_settings_file(&out_dir)?;
 
-        let package_name = if let Some(name) = &self.name {
-            name
-        } else {
-            &self.path
-        };
-
+        // `cargo new` prints the given path to the new package, so
+        // do the same here.
         config
             .shell()
-            .status("Created", format!("component `{}` package", package_name))?;
+            .status("Created", format!("component `{name}` package"))?;
 
         Ok(())
     }
@@ -129,7 +286,7 @@ impl NewCommand {
         )
     }
 
-    fn update_manifest(&self, out_dir: &Path) -> Result<()> {
+    fn update_manifest(&self, name: &PackageName, out_dir: &Path) -> Result<()> {
         let manifest_path = out_dir.join("Cargo.toml");
         let manifest = fs::read_to_string(&manifest_path).with_context(|| {
             format!("failed to read manifest file `{}`", manifest_path.display())
@@ -146,11 +303,16 @@ impl NewCommand {
         doc["lib"]["crate-type"] = value(Value::from_iter(["cdylib"].into_iter()));
 
         let mut exports = Table::new();
-        exports["interface"] = value("interface.wit");
+        exports[&name.snake] = value(
+            Path::new(&name.snake)
+                .with_extension("wit")
+                .to_string_lossy()
+                .as_ref(),
+        );
 
         let mut component = Table::new();
         component.set_implicit(true);
-        component["direct-export"] = value("interface");
+        component["direct-export"] = value(&name.snake);
         component["exports"] = Item::Table(exports);
 
         let mut metadata = Table::new();
@@ -175,30 +337,45 @@ impl NewCommand {
         })
     }
 
-    fn update_source_file(&self, out_dir: &Path) -> Result<()> {
-        const DEFAULT_SOURCE_FILE: &str = r#"use bindings::interface;
+    fn update_source_file(&self, name: &PackageName, out_dir: &Path) -> Result<()> {
+        let source_path = out_dir.join("src/lib.rs");
+        fs::write(
+            &source_path,
+            format!(
+                r#"use bindings::{snake};
 
 struct Component;
 
-impl interface::Interface for Component {
-    fn say_something() -> String {
+impl {snake}::{camel} for Component {{
+    fn hello_world() -> String {{
         "Hello, World!".to_string()
-    }
-}
+    }}
+}}
 
 bindings::export!(Component);
-"#;
-
-        let source_path = out_dir.join("src/lib.rs");
-        fs::write(&source_path, DEFAULT_SOURCE_FILE)
-            .with_context(|| format!("failed to write source file `{}`", source_path.display()))
+"#,
+                snake = name.snake,
+                camel = name.camel
+            ),
+        )
+        .with_context(|| format!("failed to write source file `{}`", source_path.display()))
     }
 
-    fn create_interface_file(&self, out_dir: &Path) -> Result<()> {
-        const DEFAULT_INTERFACE_FILE: &str = "say-something: func() -> string\n";
+    fn create_interface_file(&self, name: &PackageName, out_dir: &Path) -> Result<()> {
+        let mut interface_path = out_dir.join(&name.snake);
+        interface_path.set_extension("wit");
 
-        let interface_path = out_dir.join("interface.wit");
-        fs::write(&interface_path, DEFAULT_INTERFACE_FILE).with_context(|| {
+        fs::write(
+            &interface_path,
+            format!(
+                r#"interface {kebab} {{
+    hello-world: func() -> string
+}}
+"#,
+                kebab = name.kebab,
+            ),
+        )
+        .with_context(|| {
             format!(
                 "failed to write interface file `{}`",
                 interface_path.display()

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -57,7 +57,7 @@ fn checks_for_duplicate_exports() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --path interface.wit --direct-export export")
+        .cargo_component("add --path foo.wit --direct-export export")
         .assert()
         .stderr(contains(
             "a directly exported interface has already been specified in the manifest",
@@ -65,23 +65,23 @@ fn checks_for_duplicate_exports() -> Result<()> {
         .failure();
 
     project
-        .cargo_component("add --path interface.wit --export export")
+        .cargo_component("add --path foo.wit --export export")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit import")
+        .cargo_component("add --path foo.wit import")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit --export export")
+        .cargo_component("add --path foo.wit --export export")
         .assert()
         .stderr(contains("an export with name `export` already exists"))
         .failure();
 
     project
-        .cargo_component("add --path interface.wit --export import")
+        .cargo_component("add --path foo.wit --export import")
         .assert()
         .stderr(contains("an import with name `import` already exists"))
         .failure();
@@ -94,23 +94,23 @@ fn checks_for_duplicate_imports() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --path interface.wit import")
+        .cargo_component("add --path foo.wit import")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit --export export")
+        .cargo_component("add --path foo.wit --export export")
         .assert()
         .success();
 
     project
-        .cargo_component("add --path interface.wit import")
+        .cargo_component("add --path foo.wit import")
         .assert()
         .stderr(contains("an import with name `import` already exists"))
         .failure();
 
     project
-        .cargo_component("add --path interface.wit export")
+        .cargo_component("add --path foo.wit export")
         .assert()
         .stderr(contains("an export with name `export` already exists"))
         .failure();
@@ -123,9 +123,9 @@ fn prints_modified_manifest_for_dry_run() -> Result<()> {
     let project = Project::new("foo")?;
 
     project
-        .cargo_component("add --dry-run --path interface.wit import")
+        .cargo_component("add --dry-run --path foo.wit import")
         .assert()
-        .stdout(contains(r#"import = "interface.wit""#))
+        .stdout(contains(r#"import = "foo.wit""#))
         .success();
 
     // Assert the dependency was not added to the manifest

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -90,3 +90,17 @@ edition = "2021"
 
     Ok(())
 }
+
+#[test]
+fn it_supports_wit_keywords() -> Result<()> {
+    let project = Project::new("interface")?;
+    project
+        .cargo_component("build --release")
+        .assert()
+        .stderr(contains("Finished release [optimized] target(s)"))
+        .success();
+
+    validate_component(&project.release_wasm("interface"))?;
+
+    Ok(())
+}

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -31,7 +31,7 @@ fn it_creates_the_expected_files() -> Result<()> {
     let proj_dir = root.join("foo");
 
     assert!(proj_dir.join("Cargo.toml").is_file());
-    assert!(proj_dir.join("interface.wit").is_file());
+    assert!(proj_dir.join("foo.wit").is_file());
     assert!(proj_dir.join("src").join("lib.rs").is_file());
     assert!(proj_dir.join(".vscode").join("settings.json").is_file());
 
@@ -51,7 +51,7 @@ fn it_supports_editor_option() -> Result<()> {
     let proj_dir = root.join("foo");
 
     assert!(proj_dir.join("Cargo.toml").is_file());
-    assert!(proj_dir.join("interface.wit").is_file());
+    assert!(proj_dir.join("foo.wit").is_file());
     assert!(proj_dir.join("src").join("lib.rs").is_file());
     assert!(!proj_dir.join(".vscode").is_dir());
 
@@ -88,6 +88,36 @@ fn it_supports_name_option() -> Result<()> {
     let proj_dir = root.join("foo");
 
     assert!(fs::read_to_string(proj_dir.join("Cargo.toml"))?.contains("name = \"bar\""));
+
+    Ok(())
+}
+
+#[test]
+fn it_rejects_wit_keywords() -> Result<()> {
+    let root = create_root()?;
+
+    cargo_component("new foo --name interface")
+        .current_dir(&root)
+        .assert()
+        .stderr(contains(
+            "component name `interface` cannot be used as it is a WIT keyword",
+        ))
+        .failure();
+
+    Ok(())
+}
+
+#[test]
+fn it_rejects_rust_keywords() -> Result<()> {
+    let root = create_root()?;
+
+    cargo_component("new foo --name fn")
+        .current_dir(&root)
+        .assert()
+        .stderr(contains(
+            "component name `fn` cannot be used as it is a Rust keyword",
+        ))
+        .failure();
 
     Ok(())
 }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -93,21 +93,6 @@ fn it_supports_name_option() -> Result<()> {
 }
 
 #[test]
-fn it_rejects_wit_keywords() -> Result<()> {
-    let root = create_root()?;
-
-    cargo_component("new foo --name interface")
-        .current_dir(&root)
-        .assert()
-        .stderr(contains(
-            "component name `interface` cannot be used as it is a WIT keyword",
-        ))
-        .failure();
-
-    Ok(())
-}
-
-#[test]
 fn it_rejects_rust_keywords() -> Result<()> {
     let root = create_root()?;
 


### PR DESCRIPTION
This PR updates cargo-component's dependencies to latest.

It includes changes to `wit-component` to support the current binary format of the component model.

As a result of changes to wit-parser, interface definitions must now be wrapped in a declaring `interface <name>` scope.