### PR TITLE
Update the registry design doc (again).

### DIFF
--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -347,7 +347,7 @@ package = "my-org/my-component"
 path = "component.wit"
 
 [package.metadata.component.target.dependencies]
-wasi = "webassembly/wasi:1.2.3"
+wasi = "webassembly/wasi@1.2.3"
 
 [package.metadata.component.dependencies]
 regex = "fancy-components/regex:1.0.0"

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -350,7 +350,7 @@ path = "component.wit"
 wasi = "webassembly/wasi@1.2.3"
 
 [package.metadata.component.dependencies]
-regex = "fancy-components/regex:1.0.0"
+regex = "fancy-components/regex@1.0.0"
 transcoder = "fancy-components/transcoder:1.0.0"
 ```
 An example `component.wit`:

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -351,7 +351,7 @@ wasi = "webassembly/wasi@1.2.3"
 
 [package.metadata.component.dependencies]
 regex = "fancy-components/regex@1.0.0"
-transcoder = "fancy-components/transcoder:1.0.0"
+transcoder = "fancy-components/transcoder@1.0.0"
 ```
 An example `component.wit`:
 

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -309,7 +309,7 @@ version = "1.2.3"
 document = "command"
 
 [package.metadata.component.dependencies]
-regex = "fancy-components/regex:1.0.0"
+regex = "fancy-components/regex@1.0.0"
 transcoder = "fancy-components/transcoder:1.0.0"
 ```
 

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -181,7 +181,21 @@ using a local WIT document.
 
 #### Targeting a registry package
 
-Specifying a target from a registry package:
+You may use a shorthand form of specifying a target as follows:
+
+```toml
+[package.metadata.component]
+target = "<package-id>@<version>"
+```
+
+This is equivalent to:
+
+```toml
+[package.metadata.component]
+target = { package = "<package-id>", version = "<version>" }
+```
+
+The supported fields of `target` when referencing a registry package are:
 
 ```toml
 [package.metadata.component.target]

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -310,7 +310,7 @@ document = "command"
 
 [package.metadata.component.dependencies]
 regex = "fancy-components/regex@1.0.0"
-transcoder = "fancy-components/transcoder:1.0.0"
+transcoder = "fancy-components/transcoder@1.0.0"
 ```
 
 In this example, the component still targets the WASI command world as above.

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -107,7 +107,7 @@ This design proposes the following tables in `Cargo.toml`:
   registries), the shorthand form differs from what is supported by `cargo`:
 
   ```toml
-  name = "<package-id>:<version>"
+  name = "<package-id>@<version>"
   ```
 
   Which is equivalent to:
@@ -218,7 +218,7 @@ path = "<path>"
 world = "<world>"
 
 [package.metadata.component.target.dependencies]
-"<name>" = "<package-id>:<version>" # or any of the other forms of specifying a dependency
+"<name>" = "<package-id>@<version>" # or any of the other forms of specifying a dependency
 ...
 ```
 


### PR DESCRIPTION
[Rendered version](https://github.com/bytecodealliance/cargo-component/blob/173afdaf83fc1d892215b495a4bd45b8b2fdd60f/docs/design/registries.md)

This PR updates the registry design doc to better describe target worlds.

It now fully separates WIT package dependencies used _only_ for parsing local WIT document targets and the component dependencies.