### PR TITLE
Merge the `document` and `world` settings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,11 +243,11 @@ dependencies = [
  "url",
  "warg-crypto",
  "warg-protocol",
- "wasmparser",
+ "wasmparser 0.101.0",
  "wat",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
- "wit-component",
+ "wit-component 0.7.0",
  "wit-parser",
 ]
 
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -786,24 +786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "forrest"
-version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/registry#a0e56cafb7ea8792a5227169b4b3dd988fb5e266"
-dependencies = [
- "anyhow",
- "pbjson",
- "pbjson-build",
- "pbjson-types",
- "prost",
- "prost-build",
- "prost-types",
- "serde",
- "serde_bytes",
- "thiserror",
- "warg-crypto",
 ]
 
 [[package]]
@@ -2328,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "warg-crypto"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/registry#a0e56cafb7ea8792a5227169b4b3dd988fb5e266"
+source = "git+https://github.com/bytecodealliance/registry#99f871f340a93ca26fdb3b6d57b9f84225249106"
 dependencies = [
  "anyhow",
  "base64",
@@ -2347,11 +2329,10 @@ dependencies = [
 [[package]]
 name = "warg-protocol"
 version = "0.1.0"
-source = "git+https://github.com/bytecodealliance/registry#a0e56cafb7ea8792a5227169b4b3dd988fb5e266"
+source = "git+https://github.com/bytecodealliance/registry#99f871f340a93ca26fdb3b6d57b9f84225249106"
 dependencies = [
  "anyhow",
  "base64",
- "forrest",
  "hex 0.4.3",
  "indexmap",
  "pbjson",
@@ -2363,6 +2344,25 @@ dependencies = [
  "semver",
  "serde",
  "serde_with",
+ "thiserror",
+ "warg-crypto",
+ "warg-transparency",
+]
+
+[[package]]
+name = "warg-transparency"
+version = "0.1.0"
+source = "git+https://github.com/bytecodealliance/registry#99f871f340a93ca26fdb3b6d57b9f84225249106"
+dependencies = [
+ "anyhow",
+ "pbjson",
+ "pbjson-build",
+ "pbjson-types",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "serde",
+ "serde_bytes",
  "thiserror",
  "warg-crypto",
 ]
@@ -2455,7 +2455,20 @@ dependencies = [
  "indexmap",
  "serde",
  "wasm-encoder 0.23.0",
- "wasmparser",
+ "wasmparser 0.100.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459c9bd177f859c675baf7573905c4a1a1f63087ef8bb10e0a1c94dc167228d4"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "wasm-encoder 0.24.0",
+ "wasmparser 0.101.0",
 ]
 
 [[package]]
@@ -2463,6 +2476,16 @@ name = "wasmparser"
 version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc3222d9e47412382cc95e2f013c6a9f510bcff80af92de5665ae3ec1e4a2f6"
 dependencies = [
  "indexmap",
  "url",
@@ -2619,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea1d49787508c06dfbeeb2c6599a20fc475547b102fc3e8637ada7d67bb62969"
 dependencies = [
  "anyhow",
- "wit-component",
+ "wit-component 0.6.0",
  "wit-parser",
 ]
 
@@ -2632,7 +2655,7 @@ dependencies = [
  "heck",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
- "wit-component",
+ "wit-component 0.6.0",
 ]
 
 [[package]]
@@ -2657,8 +2680,25 @@ dependencies = [
  "log",
  "url",
  "wasm-encoder 0.23.0",
- "wasm-metadata",
- "wasmparser",
+ "wasm-metadata 0.1.2",
+ "wasmparser 0.100.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d06e30f5e23df26d6a60061086b0b17687d458b29448cb329bcff9e425c6ea3"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "url",
+ "wasm-encoder 0.24.0",
+ "wasm-metadata 0.2.0",
+ "wasmparser 0.101.0",
  "wit-parser",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 anyhow = "1.0.69"
 cargo = "0.68.0"
 cargo-util = "0.2.3"
-clap = { version = "4.1.4", features = ["derive"] }
+clap = { version = "4.1.6", features = ["derive"] }
 toml_edit = { version = "0.18.1", features = ["easy"] }
 warg-protocol = { git = "https://github.com/bytecodealliance/registry" }
 warg-crypto = { git = "https://github.com/bytecodealliance/registry" }
 wit-bindgen-core = "0.3.0"
 wit-bindgen-gen-guest-rust = "0.3.0"
-wit-parser = "0.6.0"
-wit-component = "0.6.0"
+wit-parser = "0.6.1"
+wit-component = "0.7.0"
 pretty_env_logger = { version = "0.4.0", optional = true }
 log = "0.4.17"
 heck = "0.4.1"
@@ -27,7 +27,7 @@ p256 = "0.11.1"
 rand_core = "0.6.4"
 serde_json = "1.0.93"
 async-trait = "0.1.64"
-wat = "1.0.58"
+wat = "1.0.59"
 indexmap = "1.9.2"
 hex = "0.4.3"
 
@@ -37,4 +37,4 @@ default = ["pretty_env_logger"]
 [dev-dependencies]
 assert_cmd = "2.0.8"
 predicates = "2.1.5"
-wasmparser = "0.100.0"
+wasmparser = "0.101.0"

--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -201,7 +201,6 @@ The supported fields of `target` when referencing a registry package are:
 [package.metadata.component.target]
 package = "<package-id>"
 version = "<version>"
-document = "<document>"
 world = "<world>"
 registry = "<registry>"
 ```
@@ -211,16 +210,12 @@ The `package` and `version` fields are required.
 The `package`, `version`, and `registry` fields describe which package is being 
 referenced. The `registry` field is optional.
 
-The `document` field is optional and defaults to the first document in the 
-package if there is exactly one document. If there are multiple documents, the 
-`document` field is required.
-
-The `world` field is optional and defaults to the default world of the 
-document. If the document has no default world, then the default is the first 
-world in the document if there is exactly one world. If there are multiple 
-worlds in the document, the `world` field is required.
+The `world` field is optional and defaults to the default world resolution of
+the WIT package as defined by [`Resolve::select_world`][select-world].
 
 The referenced package may be either a WIT package or a component.
+
+[select-world]: https://docs.rs/wit-parser/0.6.1/wit_parser/struct.Resolve.html#method.select_world
 
 #### Targeting a local WIT document
 
@@ -233,16 +228,15 @@ world = "<world>"
 
 [package.metadata.component.target.dependencies]
 "<name>" = "<package-id>@<version>" # or any of the other forms of specifying a dependency
-...
+
+# ...
 ```
 
 The `path` field is required and specifies the path to the WIT document 
 defining a world to target.
 
-The `world` field is optional and defaults to the default world of the 
-document. If the document has no default world, then the default is the first 
-world in the document if there is exactly one world. If there are multiple 
-worlds in the document, the `world` field is required.
+The `world` field is optional and defaults to the default world resolution of
+the WIT package as defined by [`Resolve::select_world`][select-world].
 
 The `[package.metadata.component.target.dependencies]` table is optional and 
 defines the WIT package dependencies that may be referenced in the local WIT 

--- a/tests/registry.rs
+++ b/tests/registry.rs
@@ -15,7 +15,6 @@ fn create_project(
     name: &str,
     package: &str,
     version: &str,
-    document: Option<&str>,
     world: Option<&str>,
     dependency: Option<(&str, &str)>,
     source: &str,
@@ -34,9 +33,6 @@ fn create_project(
     target.as_table_like_mut().unwrap().remove("path");
     target["package"] = value(package);
     target["version"] = value(version);
-    if let Some(document) = document {
-        target["document"] = value(document);
-    }
     if let Some(world) = world {
         target["world"] = value(world);
     }
@@ -202,7 +198,6 @@ bindings::export!(Component);
         "1.0.0",
         None,
         None,
-        None,
         source,
     )?;
     project
@@ -241,7 +236,6 @@ fn it_errors_on_missing_target_package() -> Result<()> {
         "component",
         "foo/bar",
         "1.0.0",
-        None,
         None,
         None,
         "",
@@ -296,7 +290,6 @@ bindings::export!(Component);
         "1.0.0",
         Some("foo"),
         None,
-        None,
         source,
     )?;
     project
@@ -347,7 +340,6 @@ fn it_errors_on_invalid_document() -> Result<()> {
         "1.0.0",
         Some("bar"),
         None,
-        None,
         "",
     )?;
     project
@@ -388,14 +380,13 @@ fn it_errors_on_too_many_documents() -> Result<()> {
         "1.0.0",
         None,
         None,
-        None,
         "",
     )?;
     project
         .cargo_component("build")
         .assert()
         .stderr(contains(
-            "target package `foo/bar` contains multiple documents; specify the one to use with the `document` field in the manifest file",
+            "target package `foo/bar` contains multiple documents; specify the one to use with the `world` field in the manifest file",
         ))
         .failure();
 
@@ -438,7 +429,6 @@ bindings::export!(Component);
         "component",
         "foo/bar",
         "1.0.0",
-        None,
         Some("foo"),
         None,
         source,
@@ -509,7 +499,6 @@ bindings::export!(Component);
         "1.0.0",
         Some("doc1"),
         None,
-        None,
         source,
     )?;
     project
@@ -558,8 +547,7 @@ fn it_errors_on_invalid_world() -> Result<()> {
         "component",
         "foo/bar",
         "1.0.0",
-        None,
-        Some("bar"),
+        Some("foo.bar"),
         None,
         "",
     )?;
@@ -601,7 +589,6 @@ fn it_errors_on_too_many_worlds() -> Result<()> {
         "1.0.0",
         Some("doc1"),
         None,
-        None,
         "",
     )?;
     project
@@ -635,7 +622,6 @@ fn it_errors_on_missing_dependency() -> Result<()> {
         "component",
         "foo/bar",
         "1.0.0",
-        None,
         None,
         Some(("baz", "foo/baz@1.0.0")),
         "",
@@ -671,7 +657,6 @@ fn it_errors_on_missing_dependency_version() -> Result<()> {
         "component",
         "foo/bar",
         "2.0.0",
-        None,
         None,
         None,
         "",
@@ -737,7 +722,6 @@ bindings::export!(Component);
         "foo/bar",
         "1.0.0",
         None,
-        None,
         Some(("baz", "foo/baz@1.0.0")),
         source,
     )?;
@@ -793,7 +777,7 @@ impl Foo for Component {
 bindings::export!(Component);
 "#;
 
-    let world = r#"world foo {
+    let world = r#"default world foo {
     import foo: external-package.foo.foo
     export bar: func() -> string
 }"#;
@@ -885,7 +869,6 @@ bindings::export!(Component);
         "component",
         "foo/bar",
         "1.0.0",
-        None,
         None,
         None,
         source,


### PR DESCRIPTION
This PR merges the `document` and `world` settings in Cargo.toml for specifying the target world to use from a package.

Additionally, it updates the resolution to first use `Resolve::select_world` to find the world to use.

As binary-encoded WIT packages don't currently encode a notion of a "default" world, the previous fallback is kept for parsing binary WIT packages.

Dependencies have also been updated.

Closes #51.