### PR TITLE
Implement a `--target` option for `cargo component new`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "wat",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
+ "wit-bindgen-gen-rust-lib",
  "wit-component 0.7.1",
  "wit-parser",
 ]
@@ -2115,15 +2116,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ heck = "0.4.1"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 url = { version = "2.3.1", features = ["serde"] }
-tokio = { version = "1.25.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 home = "0.5.4"
 p256 = "0.11.1"
 rand_core = "0.6.4"
@@ -32,6 +32,7 @@ indexmap = "1.9.2"
 hex = "0.4.3"
 termcolor = "1.2.0"
 wasm-metadata = "0.3.0"
+wit-bindgen-gen-rust-lib = "0.3.0"
 
 [features]
 default = ["pretty_env_logger"]

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,72 +1,22 @@
-use crate::Config;
-use anyhow::{bail, Context, Result};
+use crate::{
+    bindings::SourceGenerator,
+    metadata,
+    registry::{self, ContentLocation, RegistryPackageResolution},
+    Config,
+};
+use anyhow::{anyhow, bail, Context, Result};
 use cargo::ops::{self, NewOptions, VersionControl};
 use clap::{ArgAction, Args};
-use heck::{ToKebabCase, ToSnakeCase};
+use heck::ToKebabCase;
+use semver::VersionReq;
 use std::{
     borrow::Cow,
+    collections::HashMap,
     fmt, fs,
     path::{Path, PathBuf},
 };
 use toml_edit::{table, value, Document, InlineTable, Item, Table, Value};
-
-fn is_rust_keyword(s: &str) -> bool {
-    // TODO: source this from somewhere?
-    matches!(
-        s,
-        "as" 
-            | "async"
-            | "await"
-            | "break"
-            | "const"
-            | "continue"
-            | "crate"
-            | "dyn"
-            | "else"
-            | "enum"
-            | "extern"
-            | "false"
-            | "fn"
-            | "for"
-            | "if"
-            | "impl"
-            | "in"
-            | "let"
-            | "loop"
-            | "match"
-            | "mod"
-            | "move"
-            | "mut"
-            | "pub"
-            | "ref"
-            | "return"
-            | "self"
-            | "static"
-            | "struct"
-            | "super"
-            | "trait"
-            | "true"
-            | "type"
-            | "unsafe"
-            | "use"
-            | "where"
-            | "while"
-            // Reserved for future use
-            | "abstract"
-            | "become"
-            | "box"
-            | "do"
-            | "final"
-            | "macro"
-            | "override"
-            | "priv"
-            | "try"
-            | "typeof"
-            | "unsized"
-            | "virtual"
-            | "yield"
-    )
-}
+use url::Url;
 
 /// Create a new WebAssembly component package at <path>
 #[derive(Args)]
@@ -90,7 +40,7 @@ pub struct NewCommand {
     )]
     pub verbose: u8,
 
-    ///  Use a library template [default]
+    /// Use a library template [default]
     #[clap(long = "lib")]
     pub lib: bool,
 
@@ -122,6 +72,22 @@ pub struct NewCommand {
     #[clap(long = "editor", value_name = "EDITOR", value_parser = ["vscode", "none"])]
     pub editor: Option<String>,
 
+    /// Use the specified target WIT package.
+    #[clap(long = "target", short = 't', value_name = "TARGET")]
+    pub target: Option<String>,
+
+    /// Use the specified world within the target WIT package.
+    #[clap(long = "world", short = 'w', value_name = "WORLD", requires = "target")]
+    pub world: Option<String>,
+
+    /// Use the specified default registry when generating the package.
+    #[clap(long = "registry", value_name = "REGISTRY")]
+    pub registry: Option<String>,
+
+    /// Disable the use of `rustfmt` when generating source code.
+    #[clap(long = "no-rustfmt")]
+    pub no_rustfmt: bool,
+
     /// The path for the generated package.
     #[clap(value_name = "path")]
     pub path: PathBuf,
@@ -144,18 +110,13 @@ impl<'a> PackageName<'a> {
         };
 
         let kebab = package.to_kebab_case();
-        let snake = package.to_snake_case();
 
-        if kebab.is_empty() || snake.is_empty() {
+        if kebab.is_empty() {
             bail!("invalid component name `{package}`");
         }
 
         wit_parser::validate_id(&kebab)
             .with_context(|| format!("component name `{package}` is not a legal WIT identifier"))?;
-
-        if is_rust_keyword(&snake) {
-            bail!("component name `{package}` cannot be used as it is a Rust keyword");
-        }
 
         Ok(Self { display })
     }
@@ -186,21 +147,24 @@ impl NewCommand {
             &[],
         )?;
 
-        let opts = self.new_options(config)?;
-
-        ops::new(&opts, config.cargo())?;
-
         let out_dir = config.cargo().cwd().join(&self.path);
-        self.update_manifest(&out_dir)?;
-        self.update_source_file(&out_dir)?;
-        self.create_targets_file(&out_dir)?;
-        self.create_editor_settings_file(&out_dir)?;
+        let registries = self.registries()?;
+        let target = self.resolve_target(config, &registries).await?;
+        let source = self.generate_source(&target)?;
+
+        let opts = self.new_options(config)?;
+        ops::new(&opts, config.cargo())?;
 
         // `cargo new` prints the given path to the new package, so
         // do the same here.
         config
             .shell()
             .status("Created", format!("component `{name}` package"))?;
+
+        self.update_manifest(&out_dir, &registries, &target)?;
+        self.create_source_file(config, &out_dir, source.as_ref(), &target)?;
+        self.create_targets_file(&out_dir)?;
+        self.create_editor_settings_file(&out_dir)?;
 
         Ok(())
     }
@@ -226,7 +190,12 @@ impl NewCommand {
         )
     }
 
-    fn update_manifest(&self, out_dir: &Path) -> Result<()> {
+    fn update_manifest(
+        &self,
+        out_dir: &Path,
+        registries: &HashMap<String, metadata::Registry>,
+        target: &Option<RegistryPackageResolution>,
+    ) -> Result<()> {
         let manifest_path = out_dir.join("Cargo.toml");
         let manifest = fs::read_to_string(&manifest_path).with_context(|| {
             format!(
@@ -247,10 +216,39 @@ impl NewCommand {
 
         let mut component = Table::new();
         component.set_implicit(true);
-        component["target"] = value(InlineTable::from_iter(
-            [("path", Value::from("world.wit"))].into_iter(),
-        ));
+        component["target"] = match target.as_ref() {
+            Some(target) => value(format!(
+                "{id}@{version}",
+                id = target.id,
+                version = target.version
+            )),
+            None => value(InlineTable::from_iter(
+                [("path", Value::from("world.wit"))].into_iter(),
+            )),
+        };
         component["dependencies"] = Item::Table(Table::new());
+
+        if !registries.is_empty() {
+            let mut table = Table::new();
+            for (name, reg) in registries {
+                table[name] = match reg {
+                    metadata::Registry::Remote(url) => value(url.to_string()),
+                    metadata::Registry::Local(path) => value(InlineTable::from_iter(
+                        [(
+                            "path",
+                            Value::from(Path::new("..").join(path).to_str().ok_or_else(|| {
+                                anyhow!(
+                                    "invalid path `{path}` for local registry",
+                                    path = path.display()
+                                )
+                            })?),
+                        )]
+                        .into_iter(),
+                    )),
+                }
+            }
+            component["registries"] = Item::Table(table);
+        }
 
         let mut metadata = Table::new();
         metadata.set_implicit(true);
@@ -274,12 +272,17 @@ impl NewCommand {
         })
     }
 
-    fn update_source_file(&self, out_dir: &Path) -> Result<()> {
-        let source_path = out_dir.join("src/lib.rs");
-        fs::write(
-            &source_path,
-            r#"
-struct Component;
+    fn generate_source(&self, target: &Option<RegistryPackageResolution>) -> Result<Cow<str>> {
+        match target {
+            Some(target) => {
+                let path: Cow<Path> = match &target.location {
+                    ContentLocation::Local(path) => path.into(),
+                    ContentLocation::Remote(_) => todo!("support remote content"),
+                };
+                let generator = SourceGenerator::new(&target.id, path.as_ref(), !self.no_rustfmt);
+                generator.generate(self.world.as_deref()).map(Into::into)
+            }
+            None => Ok(r#"struct Component;
 
 impl bindings::Component for Component {
     fn hello_world() -> String {
@@ -288,9 +291,38 @@ impl bindings::Component for Component {
 }
 
 bindings::export!(Component);
-"#,
-        )
-        .with_context(|| {
+"#
+            .into()),
+        }
+    }
+
+    fn create_source_file(
+        &self,
+        config: &Config,
+        out_dir: &Path,
+        source: &str,
+        target: &Option<RegistryPackageResolution>,
+    ) -> Result<()> {
+        match target {
+            Some(target) => {
+                config.shell().status(
+                    "Generating",
+                    format!(
+                        "source file for target `{id}` v{version}",
+                        id = target.id,
+                        version = target.version
+                    ),
+                )?;
+            }
+            None => {
+                config
+                    .shell()
+                    .status("Generating", "\"hello world\" example source file")?;
+            }
+        }
+
+        let source_path = out_dir.join("src/lib.rs");
+        fs::write(&source_path, source).with_context(|| {
             format!(
                 "failed to write source file `{path}`",
                 path = source_path.display()
@@ -299,6 +331,10 @@ bindings::export!(Component);
     }
 
     fn create_targets_file(&self, out_dir: &Path) -> Result<()> {
+        if self.target.is_some() {
+            return Ok(());
+        }
+
         let path = out_dir.join("world.wit");
 
         fs::write(
@@ -342,5 +378,60 @@ default world component {
             Some("none") => Ok(()),
             _ => unreachable!(),
         }
+    }
+
+    async fn resolve_target(
+        &self,
+        config: &Config,
+        registries: &HashMap<String, metadata::Registry>,
+    ) -> Result<Option<RegistryPackageResolution>> {
+        match self.target.as_ref() {
+            Some(target) => {
+                let (id, requirement) = if target.contains('@') {
+                    let package: metadata::RegistryPackage = target.parse()?;
+                    (package.id, package.version)
+                } else {
+                    (target.as_str().into(), VersionReq::STAR)
+                };
+
+                let registry = registry::create(config, None, registries)?;
+
+                config
+                    .cargo()
+                    .shell()
+                    .status("Updating", "component registry logs")?;
+
+                registry.synchronize(&[&id]).await?;
+
+                match registry.resolve(&id, &requirement)? {
+                    Some(target) => Ok(Some(target)),
+                    None => bail!("a version of package `{id}` that satisfies version requirement `{requirement}` was not found")
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn registries(&self) -> Result<HashMap<String, metadata::Registry>> {
+        let mut registries = HashMap::new();
+
+        if let Some(registry) = self.registry.as_deref() {
+            let registry = match Url::try_from(registry) {
+                Ok(url) => metadata::Registry::Remote(url),
+                Err(_) => {
+                    let path: PathBuf = registry.into();
+                    if !path.is_dir() {
+                        bail!(
+                            "local registry `{path}` does not exist",
+                            path = path.display()
+                        );
+                    }
+                    metadata::Registry::Local(path)
+                }
+            };
+            registries.insert("default".to_string(), registry);
+        }
+
+        Ok(registries)
     }
 }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -416,17 +416,13 @@ default world component {
         let mut registries = HashMap::new();
 
         if let Some(registry) = self.registry.as_deref() {
-            let registry = match Url::try_from(registry) {
-                Ok(url) => metadata::Registry::Remote(url),
-                Err(_) => {
-                    let path: PathBuf = registry.into();
-                    if !path.is_dir() {
-                        bail!(
-                            "local registry `{path}` does not exist",
-                            path = path.display()
-                        );
-                    }
-                    metadata::Registry::Local(path)
+            // Check if the specified registry exists as a path
+            let registry = if Path::new(registry).exists() {
+                metadata::Registry::Local(registry.into())
+            } else {
+                match Url::try_from(registry) {
+                    Ok(url) => metadata::Registry::Remote(url),
+                    Err(_) => bail!("local registry `{registry}` does not exist"),
                 }
             };
             registries.insert("default".to_string(), registry);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -90,9 +90,6 @@ pub trait Registry {
     /// Resolves a package to the latest version that satisfies
     /// the given version requirement.
     ///
-    /// If the version requirement is `None`, then the latest released
-    /// version will be resolved.
-    ///
     /// Returns `Ok(None)` if no version satisfies the requirement.
     ///
     /// Yanked packages will not be considered.

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -100,7 +100,7 @@ fn it_rejects_rust_keywords() -> Result<()> {
         .current_dir(&root)
         .assert()
         .stderr(contains(
-            "component name `fn` cannot be used as it is a Rust keyword",
+            "the name `fn` cannot be used as a package name, it is a Rust keyword",
         ))
         .failure();
 


### PR DESCRIPTION
This PR implements a `--target` option that causes `cargo component new` to set the target to use in `Cargo.toml`.

It also generates `src/lib.rs` based on the exports of the target world, providing the necessary boilerplate code for users to immediately start implementing the component's exports.

A `--registry` option is also added to set the default registry of the project and is currently used to resolve the `--target` option until an internal default registry is implemented.

Additionally, a `--world` option was added to set the world to use when specifying a target WIT package.