### PR TITLE
Add a `doc` subcommand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ The `cargo component` subcommand has some analogous commands to cargo itself:
 * `cargo component add` — adds a component interface dependency to a cargo 
   manifest file.
 * `cargo component build` — builds a WebAssembly component from a Rust project
-  using the `wasm32-unknown-unknown` target by default.
+  using the `wasm32-wasi` target by default.
+* `cargo component doc` — generates API documentation for a WebAssembly component from a Rust project
+  using the `wasm32-wasi` target by default.
 * `cargo component metadata` — prints package metadata as `cargo metadata` 
   would, except it also includes the metadata of generated bindings.
 * `cargo component check` — checks the local package and all of its dependencies

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ component will target:
 
 ```wit
 default world component {
+  /// Say hello!
   export hello-world: func() -> string
 }
 ```

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use cargo::CliError;
 use cargo_component::{
     commands::{
-        AddCommand, BuildCommand, CheckCommand, ClippyCommand, MetadataCommand, NewCommand,
-        RegistryCommand, UpdateCommand,
+        AddCommand, BuildCommand, CheckCommand, ClippyCommand, DocCommand, MetadataCommand,
+        NewCommand, RegistryCommand, UpdateCommand,
     },
     config::Config,
 };
@@ -34,6 +34,7 @@ enum CargoComponent {
 pub enum Command {
     New(NewCommand),
     Build(BuildCommand),
+    Doc(DocCommand),
     Metadata(MetadataCommand),
     Check(CheckCommand),
     Add(AddCommand),
@@ -53,6 +54,7 @@ async fn main() -> Result<()> {
         CargoComponent::Component(cmd) | CargoComponent::Command(cmd) => match cmd {
             Command::New(cmd) => cmd.exec(&mut config).await,
             Command::Build(cmd) => cmd.exec(&mut config).await,
+            Command::Doc(cmd) => cmd.exec(&mut config).await,
             Command::Metadata(cmd) => cmd.exec(&mut config).await,
             Command::Check(cmd) => cmd.exec(&mut config).await,
             Command::Add(cmd) => cmd.exec(&mut config).await,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,6 +14,7 @@ mod add;
 mod build;
 mod check;
 mod clippy;
+mod doc;
 mod metadata;
 mod new;
 mod registry;
@@ -23,6 +24,7 @@ pub use self::add::*;
 pub use self::build::*;
 pub use self::check::*;
 pub use self::clippy::*;
+pub use self::doc::*;
 pub use self::metadata::*;
 pub use self::new::*;
 pub use self::registry::*;
@@ -194,6 +196,24 @@ impl CompileOptions {
             target_rustc_crate_types: None,
             rustdoc_document_private_items: false,
             honor_rust_version: true,
+        })
+    }
+}
+
+struct DocOptions {
+    pub open_result: bool,
+    pub compile_opts: CompileOptions,
+}
+
+impl DocOptions {
+    fn into_cargo_options(
+        self,
+        config: &Config,
+        mode: CompileMode,
+    ) -> Result<cargo::ops::DocOptions> {
+        Ok(cargo::ops::DocOptions {
+            open_result: self.open_result,
+            compile_opts: self.compile_opts.into_cargo_options(config, mode)?,
         })
     }
 }

--- a/src/commands/doc.rs
+++ b/src/commands/doc.rs
@@ -1,0 +1,166 @@
+use crate::{
+    commands::{workspace, CompileOptions, DocOptions},
+    Config,
+};
+use anyhow::Result;
+use cargo::core::compiler::CompileMode;
+use clap::{ArgAction, Args};
+use std::path::PathBuf;
+
+/// Generate API documentation for a WebAssembly component API.
+#[derive(Args)]
+pub struct DocCommand {
+    /// Opens the docs in a browser after the operation
+    #[clap(long = "open")]
+    pub open_result: bool,
+
+    /// Don't build documentation for dependencies
+    #[clap(long = "no-deps")]
+    pub no_deps: bool,
+
+    /// Do not print cargo log messages
+    #[clap(long = "quiet", short = 'q')]
+    pub quiet: bool,
+
+    /// Package to document (see `cargo help pkgid`)
+    #[clap(long = "package", short = 'p', value_name = "SPEC")]
+    pub packages: Vec<String>,
+
+    /// Document all packages in the workspace
+    #[clap(long = "workspace", alias = "all")]
+    pub workspace: bool,
+
+    /// Exclude packages from the documentation
+    #[clap(long = "exclude", value_name = "SPEC")]
+    pub exclude: Vec<String>,
+
+    /// Number of parallel jobs, defaults to # of CPUs
+    #[clap(long = "jobs", short = 'j', value_name = "N")]
+    pub jobs: Option<i32>,
+
+    /// Document only this package's library
+    #[clap(long = "lib")]
+    pub lib: bool,
+
+    /// Document artifacts in release mode, with optimizations
+    #[clap(long = "release", short = 'r')]
+    pub release: bool,
+
+    /// Space or comma separated list of features to activate
+    #[clap(long = "features", value_name = "FEATURES")]
+    pub features: Vec<String>,
+
+    /// Activate all available features
+    #[clap(long = "all-features")]
+    pub all_features: bool,
+
+    /// Do not activate the `default` feature
+    #[clap(long = "no-default-features")]
+    pub no_default_features: bool,
+
+    /// Document for the target triple (defaults to `wasm32-wasi`)
+    #[clap(long = "target", value_name = "TRIPLE")]
+    pub targets: Vec<String>,
+
+    /// Document all targets
+    #[clap(long = "all-targets")]
+    pub all_targets: bool,
+
+    /// Directory for all generated artifacts
+    #[clap(long = "target-dir", value_name = "DIRECTORY")]
+    pub target_dir: Option<PathBuf>,
+
+    /// Path to Cargo.toml
+    #[clap(long = "manifest-path", value_name = "PATH")]
+    pub manifest_path: Option<PathBuf>,
+
+    /// Use verbose output (-vv very verbose/build.rs output)
+    #[clap(
+        long = "verbose",
+        short = 'v',
+        action = ArgAction::Count
+    )]
+    pub verbose: u8,
+
+    /// Coloring: auto, always, never
+    #[clap(long = "color", value_name = "WHEN")]
+    pub color: Option<String>,
+
+    /// Require Cargo.lock and cache are up to date
+    #[clap(long = "frozen")]
+    pub frozen: bool,
+
+    /// Do not abort the build as soon as there is an error (unstable)
+    #[clap(long = "keep-going")]
+    pub keep_going: bool,
+
+    /// Require Cargo.lock is up to date
+    #[clap(long = "locked")]
+    pub locked: bool,
+
+    /// Run without accessing the network
+    #[clap(long = "offline")]
+    pub offline: bool,
+
+    /// Error format
+    #[clap(long = "message-format", value_name = "FMT")]
+    pub message_format: Option<String>,
+
+    /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+    #[clap(long = "Z", value_name = "FLAG")]
+    pub unstable_flags: Vec<String>,
+
+    /// Force generation of all dependency bindings.
+    #[clap(long = "generate")]
+    pub generate: bool,
+}
+
+impl DocCommand {
+    /// Executes the command.
+    pub async fn exec(self, config: &mut Config) -> Result<()> {
+        log::debug!("executing compile command");
+
+        config.cargo_mut().configure(
+            u32::from(self.verbose),
+            self.quiet,
+            self.color.as_deref(),
+            self.frozen,
+            self.locked,
+            self.offline,
+            &self.target_dir,
+            &self.unstable_flags,
+            &[],
+        )?;
+
+        let force_generation = self.generate;
+        let no_deps = self.no_deps;
+        let workspace = workspace(self.manifest_path.as_deref(), config)?;
+        let options = DocOptions::from(self)
+            .into_cargo_options(config, CompileMode::Doc { deps: !no_deps })?;
+
+        crate::doc(config, workspace, &options, force_generation).await
+    }
+}
+
+impl From<DocCommand> for DocOptions {
+    fn from(cmd: DocCommand) -> Self {
+        DocOptions {
+            open_result: cmd.open_result,
+            compile_opts: CompileOptions {
+                workspace: cmd.workspace,
+                exclude: cmd.exclude,
+                packages: cmd.packages,
+                targets: cmd.targets,
+                jobs: cmd.jobs,
+                message_format: cmd.message_format,
+                release: cmd.release,
+                features: cmd.features,
+                all_features: cmd.all_features,
+                no_default_features: cmd.no_default_features,
+                lib: cmd.lib,
+                all_targets: cmd.all_targets,
+                keep_going: cmd.keep_going,
+            },
+        }
+    }
+}

--- a/src/commands/doc.rs
+++ b/src/commands/doc.rs
@@ -118,7 +118,7 @@ pub struct DocCommand {
 impl DocCommand {
     /// Executes the command.
     pub async fn exec(self, config: &mut Config) -> Result<()> {
-        log::debug!("executing compile command");
+        log::debug!("executing document command");
 
         config.cargo_mut().configure(
             u32::from(self.verbose),

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -285,6 +285,7 @@ impl NewCommand {
             None => Ok(r#"struct Component;
 
 impl bindings::Component for Component {
+    /// Say hello!
     fn hello_world() -> String {
         "Hello, World!".to_string()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use bindings::BindingsGenerator;
 use cargo::{
     core::{SourceId, Summary, Workspace},
-    ops::{self, CompileOptions, ExportInfo, OutputMetadataOptions, UpdateOptions},
+    ops::{self, CompileOptions, DocOptions, ExportInfo, OutputMetadataOptions, UpdateOptions},
 };
 use cargo_util::paths::link_or_copy;
 use registry::{
@@ -288,6 +288,20 @@ pub async fn compile(
         create_component(config, path)?;
     }
 
+    Ok(())
+}
+
+/// Generate API documentation for the given workspace and compile options.
+///
+/// It is expected that the current package contains a `package.metadata.component` section.
+pub async fn doc(
+    config: &Config,
+    mut workspace: Workspace<'_>,
+    options: &DocOptions,
+    force_generation: bool,
+) -> Result<()> {
+    generate_workspace_bindings(config, &mut workspace, force_generation).await?;
+    ops::doc(&workspace, options)?;
     Ok(())
 }
 

--- a/tests/doc.rs
+++ b/tests/doc.rs
@@ -1,0 +1,42 @@
+use crate::support::*;
+use anyhow::{Context, Result};
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::fs;
+
+mod support;
+
+#[test]
+fn help() {
+    for arg in ["help doc", "doc -h", "doc --help"] {
+        cargo_component(arg)
+            .assert()
+            .stdout(contains(
+                "Generate API documentation for a WebAssembly component API",
+            ))
+            .success();
+    }
+}
+
+#[test]
+fn it_documents() -> Result<()> {
+    let project = Project::new("foo")?;
+    project
+        .cargo_component("doc")
+        .assert()
+        .stderr(contains("Finished dev [unoptimized + debuginfo] target(s)"))
+        .success();
+
+    let doc = project.build_dir().join("wasm32-wasi").join("doc");
+
+    let path = doc.join("src").join("foo").join("lib.rs.html");
+    let content = fs::read(&path).with_context(|| {
+        format!(
+            "failed to read generated doc file `{path}`",
+            path = path.display()
+        )
+    })?;
+    assert!(std::str::from_utf8(&content)?.contains("Say hello!"));
+
+    Ok(())
+}


### PR DESCRIPTION
Add a `cargo component doc` subcommand, which generates API documentation for the user's component and optionally its dependencies.