### PR TITLE
Implement a `wit publish` command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
+checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -2641,9 +2641,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The `cargo component` subcommand has some analogous commands to cargo itself:
   component registry.
 * `cargo component key` - manages signing keys for publishing WebAssembly 
   components.
+* `cargo component wit` - manages the target WIT package of the component.
 
 More commands will be added over time.
 

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -3,7 +3,7 @@ use cargo::CliError;
 use cargo_component::{
     commands::{
         AddCommand, BuildCommand, CheckCommand, ClippyCommand, DocCommand, KeyCommand,
-        MetadataCommand, NewCommand, PublishCommand, UpdateCommand,
+        MetadataCommand, NewCommand, PublishCommand, UpdateCommand, WitCommand,
     },
     config::Config,
 };
@@ -42,6 +42,7 @@ pub enum Command {
     Update(UpdateCommand),
     Publish(PublishCommand),
     Key(KeyCommand),
+    Wit(WitCommand),
 }
 
 #[tokio::main]
@@ -63,6 +64,7 @@ async fn main() -> Result<()> {
             Command::Update(cmd) => cmd.exec(&mut config).await,
             Command::Publish(cmd) => cmd.exec(&mut config).await,
             Command::Key(cmd) => cmd.exec(&mut config).await,
+            Command::Wit(cmd) => cmd.exec(&mut config).await,
         },
     } {
         cargo::exit_with_error(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -20,6 +20,7 @@ mod metadata;
 mod new;
 mod publish;
 mod update;
+mod wit;
 
 pub use self::add::*;
 pub use self::build::*;
@@ -31,6 +32,7 @@ pub use self::metadata::*;
 pub use self::new::*;
 pub use self::publish::*;
 pub use self::update::*;
+pub use self::wit::*;
 
 fn root_manifest(manifest_path: Option<&Path>, config: &Config) -> Result<PathBuf> {
     match manifest_path {

--- a/src/commands/wit.rs
+++ b/src/commands/wit.rs
@@ -1,0 +1,175 @@
+use crate::{
+    commands::workspace, metadata::ComponentMetadata, registry, signing, Config, PublishWitOptions,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use cargo::ops::Packages;
+use clap::{ArgAction, Args, Subcommand};
+use semver::Version;
+use std::path::PathBuf;
+use url::Url;
+use warg_crypto::signing::PrivateKey;
+
+/// Manages the target WIT package.
+#[derive(Args)]
+pub struct WitCommand {
+    /// The subcommand to execute.
+    #[clap(subcommand)]
+    pub command: WitSubcommand,
+}
+
+impl WitCommand {
+    /// Executes the command.
+    pub async fn exec(self, config: &mut Config) -> Result<()> {
+        log::debug!("executing wit command");
+
+        match self.command {
+            WitSubcommand::Publish(cmd) => cmd.exec(config).await,
+        }
+    }
+}
+
+/// The subcommand to execute.
+#[derive(Subcommand)]
+pub enum WitSubcommand {
+    /// Publishes the target WIT package to a registry.
+    Publish(WitPublishCommand),
+}
+
+/// Publishes the target WIT package to a registry.
+#[derive(Args)]
+#[clap(disable_version_flag = true)]
+pub struct WitPublishCommand {
+    /// Do not print cargo log messages
+    #[clap(long = "quiet", short = 'q')]
+    pub quiet: bool,
+
+    /// Use verbose output (-vv very verbose/build.rs output)
+    #[clap(
+        long = "verbose",
+        short = 'v',
+        action = ArgAction::Count
+    )]
+    pub verbose: u8,
+
+    /// Coloring: auto, always, never
+    #[clap(long = "color", value_name = "WHEN")]
+    pub color: Option<String>,
+
+    /// Path to the manifest to publish the WIT package for.
+    #[clap(long = "manifest-path", value_name = "PATH")]
+    pub manifest_path: Option<PathBuf>,
+
+    /// Require Cargo.lock and cache are up to date
+    #[clap(long = "frozen")]
+    pub frozen: bool,
+
+    /// Directory for all generated artifacts
+    #[clap(long = "target-dir", value_name = "DIRECTORY")]
+    pub target_dir: Option<PathBuf>,
+
+    /// Require Cargo.lock is up to date
+    #[clap(long = "locked")]
+    pub locked: bool,
+
+    /// Run without accessing the network
+    #[clap(long = "offline")]
+    pub offline: bool,
+
+    /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+    #[clap(long = "Z", value_name = "FLAG")]
+    pub unstable_flags: Vec<String>,
+
+    /// Don't actually publish the package.
+    #[clap(long = "dry-run")]
+    pub dry_run: bool,
+
+    /// Cargo package to publish the WIT package for (see `cargo help pkgid`)
+    #[clap(long = "package", short = 'p', value_name = "SPEC")]
+    pub cargo_package: Option<String>,
+
+    /// The user name to use for the signing key.
+    #[clap(long, short, value_name = "USER", default_value = "default")]
+    pub user: String,
+
+    /// The registry to publish to.
+    #[clap(long = "registry", value_name = "REGISTRY")]
+    pub registry: Option<String>,
+
+    /// Initialize a new package in the registry.
+    #[clap(long = "init")]
+    pub init: bool,
+
+    /// Overwrite the version of the package being published.
+    #[clap(long = "version", value_name = "VERSION")]
+    pub version: Option<Version>,
+
+    /// The name of the package being published.
+    #[clap(value_name = "PACKAGE")]
+    pub name: String,
+}
+
+impl WitPublishCommand {
+    /// Executes the command.
+    pub async fn exec(self, config: &mut Config) -> Result<()> {
+        config.cargo_mut().configure(
+            u32::from(self.verbose),
+            self.quiet,
+            self.color.as_deref(),
+            self.frozen,
+            self.locked,
+            self.offline,
+            &self.target_dir,
+            &self.unstable_flags,
+            &[],
+        )?;
+
+        let ws = workspace(self.manifest_path.as_deref(), config)?;
+        let package = if let Some(ref inner) = self.cargo_package {
+            let pkg = Packages::from_flags(false, vec![], vec![inner.clone()])?;
+            pkg.get_packages(&ws)?[0]
+        } else {
+            ws.current()?
+        };
+
+        let metadata = match ComponentMetadata::from_package(package)? {
+            Some(metadata) => metadata,
+            None => bail!(
+                "manifest `{path}` is not a WebAssembly component package",
+                path = package.manifest_path().display(),
+            ),
+        };
+
+        let url = registry::find_url(
+            config,
+            self.registry.as_deref(),
+            &metadata.section.registries,
+        )?;
+
+        let signing_key: PrivateKey = if let Ok(key) = std::env::var("CARGO_COMPONENT_PUBLISH_KEY")
+        {
+            key.parse().context("failed to parse signing key from `CARGO_COMPONENT_PUBLISH_KEY` environment variable")?
+        } else {
+            let url: Url = url
+                .parse()
+                .with_context(|| format!("failed to parse registry URL `{url}`"))?;
+
+            signing::get_signing_key(
+                url.host_str()
+                    .ok_or_else(|| anyhow!("registry URL `{url}` has no host"))?,
+                &self.user,
+            )?
+        };
+
+        let options = PublishWitOptions {
+            cargo_package: self.cargo_package.as_deref(),
+            name: &self.name,
+            version: self.version.as_ref().unwrap_or(&metadata.version),
+            url,
+            signing_key,
+            init: self.init,
+            dry_run: self.dry_run,
+        };
+
+        crate::publish_wit(config, ws, &options).await
+    }
+}

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -1,9 +1,8 @@
-use std::fs;
-
 use crate::support::*;
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use predicates::str::contains;
+use std::fs;
 
 mod support;
 

--- a/tests/wit.rs
+++ b/tests/wit.rs
@@ -1,0 +1,85 @@
+use crate::support::*;
+use anyhow::Result;
+use assert_cmd::prelude::*;
+use predicates::str::contains;
+use std::fs;
+use toml_edit::{value, Document, InlineTable, Value};
+
+mod support;
+
+#[test]
+fn help() {
+    for arg in ["help wit", "wit -h", "wit --help"] {
+        cargo_component(arg)
+            .assert()
+            .stdout(contains("Manages the target WIT package"))
+            .success();
+    }
+
+    for arg in ["help wit publish", "wit publish -h", "wit publish --help"] {
+        cargo_component(arg)
+            .assert()
+            .stdout(contains("Publishes the target WIT package to a registry"))
+            .success();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_publishes_a_wit_package() -> Result<()> {
+    let root = create_root()?;
+    let (_server, config) = spawn_server(&root).await?;
+    config.write_to_file(&root.join("warg-config.json"))?;
+
+    let project = Project::with_root(&root, "foo", "")?;
+
+    let wit = r#"default interface bar {
+    baz: func() -> string
+}
+
+default world foo {}
+"#;
+
+    fs::write(project.root().join("wit/world.wit"), wit)?;
+
+    project
+        .cargo_component("wit publish foo --init")
+        .env("CARGO_COMPONENT_PUBLISH_KEY", test_signing_key())
+        .assert()
+        .stderr(contains("Published package `foo` v0.1.0"))
+        .success();
+
+    let project = Project::with_root(&root, "bar", "")?;
+
+    let wit = r#"default world bar {
+    import bar: foo.%world.bar
+}
+"#;
+
+    fs::write(project.root().join("wit/world.wit"), wit)?;
+
+    let manifest_path = project.root().join("Cargo.toml");
+    let manifest = fs::read_to_string(&manifest_path)?;
+    let mut doc: Document = manifest.parse()?;
+    doc["package"]["metadata"]["component"]["target"] = value(InlineTable::from_iter(
+        [
+            ("path", Value::from("wit/world.wit")),
+            (
+                "dependencies",
+                Value::from(InlineTable::from_iter(
+                    [("foo", Value::from("foo@0.1.0"))].into_iter(),
+                )),
+            ),
+        ]
+        .into_iter(),
+    ));
+    fs::write(manifest_path, doc.to_string())?;
+
+    project
+        .cargo_component("wit publish bar --init")
+        .env("CARGO_COMPONENT_PUBLISH_KEY", test_signing_key())
+        .assert()
+        .stderr(contains("Published package `bar` v0.1.0"))
+        .success();
+
+    Ok(())
+}


### PR DESCRIPTION
This PR implements a `wit publish` command that will publish the local target WIT package for a component to a warg registry.

It also implements support for generating bindings for interface exports on component dependencies.