### PR TITLE
Allow WIT package dependencies to be shared.

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -216,6 +216,7 @@ fn it_builds_with_local_wit_deps() -> Result<()> {
     let mut dependencies = Table::new();
     dependencies["foo:bar"]["path"] = value("wit/deps/foo-bar");
     dependencies["bar:baz"]["path"] = value("wit/deps/bar-baz/qux.wit");
+    dependencies["baz:qux"]["path"] = value("wit/deps/foo-bar/deps/baz-qux/qux.wit");
 
     doc["package"]["metadata"]["component"]["target"]["dependencies"] = Item::Table(dependencies);
     fs::write(manifest_path, doc.to_string())?;
@@ -247,6 +248,7 @@ interface baz {
         project.root().join("wit/deps/bar-baz/qux.wit"),
         "package bar:baz
 interface qux {
+    use baz:qux/qux.{ty}
     qux: func()
 }",
     )?;


### PR DESCRIPTION
This PR removes calls to `Resolve::push_dir` when processing target dependencies.

As a result, no WIT files will be parsed from a `deps` directory automatically, so each dependency must be specified in the target dependencies table.

This change performs roughly the same work that `push_dir` was doing, namely the topological sort of the dependencies so that they are parsed in the correct order.

It should now be possible to share a target dependency between other target dependencies, much like one would expect from the `deps` directory behavior from `Resolve::push_dir`.