### PR TITLE
Export wasi adapter version even if git fails

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,12 +5,18 @@ const WASI_ADAPTER_VERSION: &str = "d1a7628";
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    commit_info();
+    println!("cargo:rustc-env=WASI_ADAPTER_VERSION={WASI_ADAPTER_VERSION}");
+    if !commit_info() {
+        println!(
+            "cargo:rustc-env=CARGO_VERSION_INFO={} (wasi:{WASI_ADAPTER_VERSION})",
+            env!("CARGO_PKG_VERSION"),
+        );
+    }
 }
 
-fn commit_info() {
+fn commit_info() -> bool {
     if !Path::new(".git").exists() {
-        return;
+        return false;
     }
     let output = match Command::new("git")
         .arg("log")
@@ -21,7 +27,7 @@ fn commit_info() {
         .output()
     {
         Ok(output) if output.status.success() => output,
-        _ => return,
+        _ => return false,
     };
     let stdout = String::from_utf8(output.stdout).unwrap();
     let mut parts = stdout.split_whitespace();
@@ -33,5 +39,5 @@ fn commit_info() {
         next(),
         next()
     );
-    println!("cargo:rustc-env=WASI_ADAPTER_VERSION={WASI_ADAPTER_VERSION}")
+    true
 }


### PR DESCRIPTION
The package fails to build when it is not in a git repository due to the usage of `env!("WASI_ADAPTER_VERSION")`, this fixes the issue