### PR TITLE
Fix structure of `Resolve` with an empty world

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -563,12 +563,13 @@ publish = false
         });
 
         let world = resolve.worlds.alloc(World {
-            name,
+            name: name.clone(),
             docs: Default::default(),
             imports: Default::default(),
             exports: Default::default(),
             package: Some(package),
         });
+        resolve.packages[package].worlds.insert(name, world);
 
         (resolve, world)
     }


### PR DESCRIPTION
This fixes a mistake where the `Resolve` synthesized for an empty WIT package had a world but the world wasn't listed in the `Package` which caused an invalid custom section to be produced where no world was emitted. The world injected is registered with its parent package here to establish the relationship which avoids a bad custom section.