### PR TITLE
Add an optional configuration to disable `rustfmt`

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -222,7 +222,12 @@ publish = false
         })?;
 
         let opts = Opts {
-            rustfmt: true,
+            rustfmt: self
+                .resolution
+                .metadata
+                .section
+                .rustfmt_bindings
+                .unwrap_or(true),
             macro_export: true,
             macro_call_prefix: Some("bindings::".to_string()),
             export_macro_name: Some("export".to_string()),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -298,6 +298,9 @@ pub struct ComponentSection {
     pub dependencies: HashMap<PackageId, Dependency>,
     /// The registries to use for the component.
     pub registries: HashMap<String, Url>,
+    /// Whether or not to run `rustfmt` over generated bindings.
+    #[serde(rename = "rustfmt-bindings")]
+    pub rustfmt_bindings: Option<bool>,
 }
 
 /// Represents cargo metadata for a WebAssembly component.


### PR DESCRIPTION
Currently `wit-bindgen` is a relatively dumb code generator and the generated code can fail in `rustfmt` due to long lines and things like that. I'm not sure how best to fix this in `wit-bindgen` or how best to communicate this to `rustfmt` (or if it's even a bug there). One option would be to ignore `rustfmt` failures in `wit-bindgen` but that seems not great because then there's not a great means to communicate the non-fatal error.

In lieu of solving some of these thornier issues I figured it'd be good to at least have an escape hatch in `cargo component` to disable `rustfmt` in case errors crop up again in the future.