### PR TITLE
Use git dependency for bindings crate.

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -17,11 +17,11 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use toml_edit::{table, value, Document, Item, Table, Value};
+use toml_edit::{table, value, Document, InlineTable, Item, Table, Value};
 use url::Url;
 
 const BINDINGS_CRATE_NAME: &str = "cargo-component-bindings";
-const BINDINGS_CRATE_VERSION: &str = "0.1.0";
+const BINDINGS_CRATE_URL: &str = "https://github.com/bytecodealliance/cargo-component";
 
 fn escape_wit(s: &str) -> Cow<str> {
     match s {
@@ -306,7 +306,8 @@ impl NewCommand {
         metadata["component"] = Item::Table(component);
 
         doc["package"]["metadata"] = Item::Table(metadata);
-        doc["dependencies"][BINDINGS_CRATE_NAME] = value(BINDINGS_CRATE_VERSION);
+        doc["dependencies"][BINDINGS_CRATE_NAME] =
+            value(InlineTable::from_iter([("git", BINDINGS_CRATE_URL)]));
 
         fs::write(&manifest_path, doc.to_string()).with_context(|| {
             format!(


### PR DESCRIPTION
This PR updates the `cargo component new` command to use a git reference to the `cargo-component-bindings` crate until it is published to crates.io with the rest of `cargo-component`.