### PR TITLE
Specify which binary to select in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ may cause build errors for existing component projects.
 To install the `cargo component` subcommand, run the following command:
 
 ```
-cargo install --git https://github.com/bytecodealliance/cargo-component --locked
+cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component --locked
 ```
 
 The [currently published crate](https://crates.io/crates/cargo-component)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ may cause build errors for existing component projects.
 To install the `cargo component` subcommand, run the following command:
 
 ```
-cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component --locked
+cargo install --git https://github.com/bytecodealliance/cargo-component --locked cargo-component
 ```
 
 The [currently published crate](https://crates.io/crates/cargo-component)

--- a/crates/wit/README.md
+++ b/crates/wit/README.md
@@ -14,7 +14,7 @@ for defining interfaces, types, and worlds used in WebAssembly components.
 ## Installation
 
 ```
-cargo install --bin wit --locked --git https://github.com/bytecodealliance/cargo-component
+cargo install --bin wit --locked --git https://github.com/bytecodealliance/cargo-component wit
 ```
 
 ## Initializing a WIT package

--- a/crates/wit/README.md
+++ b/crates/wit/README.md
@@ -14,7 +14,7 @@ for defining interfaces, types, and worlds used in WebAssembly components.
 ## Installation
 
 ```
-cargo install --bin wit --locked --git https://github.com/bytecodealliance/cargo-component wit
+cargo install --git https://github.com/bytecodealliance/cargo-component --locked wit
 ```
 
 ## Initializing a WIT package


### PR DESCRIPTION
Installing `cargo-component` now gives this error:

```rust
cargo install --git https://github.com/bytecodealliance/cargo-component

    Updating git repository `https://github.com/bytecodealliance/cargo-component`
error: multiple packages with binaries found: cargo-component, wit. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/bytecodealliance/cargo-component cargo-component`.
```

So we need to specify which "crate" to install.

Interestingly, I was getting the same error with the `wit` command that contained `--bin wit`, so I added the `wit` package there too. I am not sure what the `--bin wit` flag is doing.

I am on Windows 10, using Git Bash, if that's relevant.