### PR TITLE
Refactor the commands to prevent cargo option parsing for built-ins.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ name = "cargo-component-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
  "indexmap 2.0.0",
  "keyring",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,6 +29,7 @@ wit-component = { workspace = true }
 wit-parser = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
+clap = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -1,0 +1,41 @@
+//! Module for common command implementation.
+
+use crate::terminal::{Color, Terminal, Verbosity};
+use clap::{ArgAction, Args};
+
+/// Common options for commands.
+#[derive(Args)]
+pub struct CommonOptions {
+    /// Do not print log messages
+    #[clap(long = "quiet", short = 'q')]
+    pub quiet: bool,
+
+    /// Use verbose output (-vv very verbose output)
+    #[clap(
+        long = "verbose",
+        short = 'v',
+        action = ArgAction::Count
+    )]
+    pub verbose: u8,
+
+    /// Coloring: auto, always, never
+    #[clap(long = "color", value_name = "WHEN")]
+    pub color: Option<Color>,
+}
+
+impl CommonOptions {
+    /// Creates a new terminal from the common options.
+    pub fn new_terminal(&self) -> Terminal {
+        Terminal::new(
+            if self.quiet {
+                Verbosity::Quiet
+            } else {
+                match self.verbose {
+                    0 => Verbosity::Normal,
+                    _ => Verbosity::Verbose,
+                }
+            },
+            self.color.unwrap_or_default(),
+        )
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ use semver::VersionReq;
 use std::str::FromStr;
 use warg_protocol::registry::PackageId;
 
+pub mod command;
 pub mod keyring;
 pub mod lock;
 pub mod progress;

--- a/crates/core/src/terminal.rs
+++ b/crates/core/src/terminal.rs
@@ -39,6 +39,16 @@ impl FromStr for Color {
     }
 }
 
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto"),
+            Self::Never => write!(f, "never"),
+            Self::Always => write!(f, "always"),
+        }
+    }
+}
+
 /// The requested verbosity of output.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Verbosity {

--- a/crates/wit/src/commands.rs
+++ b/crates/wit/src/commands.rs
@@ -1,8 +1,5 @@
 //! Module for CLI commands.
 
-use cargo_component_core::terminal::{Color, Terminal, Verbosity};
-use clap::{ArgAction, Args};
-
 mod add;
 mod build;
 mod init;
@@ -16,39 +13,3 @@ pub use init::*;
 pub use key::*;
 pub use publish::*;
 pub use update::*;
-
-/// Common options for commands.
-#[derive(Args)]
-pub struct CommonOptions {
-    /// Do not print log messages
-    #[clap(long = "quiet", short = 'q')]
-    pub quiet: bool,
-
-    /// Use verbose output (-vv very verbose output)
-    #[clap(
-        long = "verbose",
-        short = 'v',
-        action = ArgAction::Count
-    )]
-    pub verbose: u8,
-
-    /// Coloring: auto, always, never
-    #[clap(long = "color", value_name = "WHEN")]
-    pub color: Option<Color>,
-}
-
-impl CommonOptions {
-    fn new_terminal(&self) -> Terminal {
-        Terminal::new(
-            if self.quiet {
-                Verbosity::Quiet
-            } else {
-                match self.verbose {
-                    0 => Verbosity::Normal,
-                    _ => Verbosity::Verbose,
-                }
-            },
-            self.color.unwrap_or_default(),
-        )
-    }
-}

--- a/crates/wit/src/commands/add.rs
+++ b/crates/wit/src/commands/add.rs
@@ -1,10 +1,10 @@
-use super::CommonOptions;
 use crate::{
     config::{Config, CONFIG_FILE_NAME},
     resolve_dependencies,
 };
 use anyhow::{bail, Context, Result};
 use cargo_component_core::{
+    command::CommonOptions,
     registry::{Dependency, DependencyResolution, DependencyResolver, RegistryPackage},
     terminal::Terminal,
     VersionedPackageId,

--- a/crates/wit/src/commands/build.rs
+++ b/crates/wit/src/commands/build.rs
@@ -1,9 +1,9 @@
-use super::CommonOptions;
 use crate::{
     build_wit_package,
     config::{Config, CONFIG_FILE_NAME},
 };
 use anyhow::{Context, Result};
+use cargo_component_core::command::CommonOptions;
 use clap::Args;
 use std::{fs, path::PathBuf};
 

--- a/crates/wit/src/commands/init.rs
+++ b/crates/wit/src/commands/init.rs
@@ -1,7 +1,6 @@
-use super::CommonOptions;
 use crate::config::{ConfigBuilder, CONFIG_FILE_NAME};
 use anyhow::{bail, Result};
-use cargo_component_core::registry::DEFAULT_REGISTRY_NAME;
+use cargo_component_core::{command::CommonOptions, registry::DEFAULT_REGISTRY_NAME};
 use clap::Args;
 use std::path::PathBuf;
 use url::Url;

--- a/crates/wit/src/commands/key.rs
+++ b/crates/wit/src/commands/key.rs
@@ -1,6 +1,6 @@
-use super::CommonOptions;
 use anyhow::{bail, Context, Result};
 use cargo_component_core::{
+    command::CommonOptions,
     keyring::{self, delete_signing_key, get_signing_key, get_signing_key_entry, set_signing_key},
     terminal::{Colors, Terminal},
 };

--- a/crates/wit/src/commands/publish.rs
+++ b/crates/wit/src/commands/publish.rs
@@ -1,10 +1,9 @@
-use super::CommonOptions;
 use crate::{
     config::{Config, CONFIG_FILE_NAME},
     publish_wit_package, PublishOptions,
 };
 use anyhow::{Context, Result};
-use cargo_component_core::{keyring::get_signing_key, registry::find_url};
+use cargo_component_core::{command::CommonOptions, keyring::get_signing_key, registry::find_url};
 use clap::Args;
 use warg_client::RegistryUrl;
 use warg_crypto::signing::PrivateKey;

--- a/crates/wit/src/commands/update.rs
+++ b/crates/wit/src/commands/update.rs
@@ -1,6 +1,6 @@
-use super::CommonOptions;
 use crate::config::{Config, CONFIG_FILE_NAME};
 use anyhow::{Context, Result};
+use cargo_component_core::command::CommonOptions;
 use clap::Args;
 
 /// Update dependencies as recorded in the lock file.


### PR DESCRIPTION
This PR refactors the commands such that the built-in commands do not parse cargo options.

It will allow the built-in commands to fully define what options they support irrespective of what options cargo might support (e.g. `target`).