### PR TITLE
Add `--path` to `cargo component add`

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -56,7 +56,7 @@ pub struct AddCommand {
     #[clap(long = "target")]
     pub target: bool,
 
-    /// Add a package dependency to this directory.
+    /// Add a package dependency to a file or directory.
     #[clap(long = "path", value_name = "PATH")]
     pub path: Option<PathBuf>,
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -183,8 +183,10 @@ impl AddCommand {
         };
 
         let mut config = InlineTable::new();
+        let mut key = self.package.id.as_ref();
 
-        if self.id.is_some() {
+        if let Some(id) = self.id.as_ref() {
+            key = id.as_ref();
             config.insert("package", Value::from(self.package.id.to_string()));
         }
 
@@ -193,10 +195,10 @@ impl AddCommand {
         }
 
         if config.is_empty() {
-            dependencies[self.package.id.as_ref()] = value(version);
+            dependencies[key] = value(version);
         } else {
             config.insert("version", Value::from(version));
-            dependencies[self.package.id.as_ref()] = value(config);
+            dependencies[key] = value(config);
         }
 
         if self.dry_run {

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -91,7 +91,6 @@ async fn adds_dependencies_to_target_component() -> Result<()> {
         .stderr(contains("Added dependency `foo:bar` with version `1.1.0`"));
 
     let manifest = fs::read_to_string(project.root().join("Cargo.toml"))?;
-    println!("manifest = {manifest}");
     assert!(contains(r#""foo:bar" = "1.1.0""#).eval(&manifest));
     assert!(contains("package.metadata.component.target.dependencies").eval(&manifest));
 
@@ -101,6 +100,15 @@ async fn adds_dependencies_to_target_component() -> Result<()> {
         .stderr(contains(
             "cannot add dependency `foo:bar` as it conflicts with an existing dependency",
         ));
+
+    project
+        .cargo_component("add --target --path foo/baz foo:baz")
+        .assert()
+        .stderr(contains("Added dependency `foo:baz` with version `*`"));
+
+    let manifest = fs::read_to_string(project.root().join("Cargo.toml"))?;
+    assert!(contains(r#""foo:baz" = { path = "foo/baz", version = "*" }"#).eval(&manifest));
+
     Ok(())
 }
 

--- a/tests/add.rs
+++ b/tests/add.rs
@@ -104,10 +104,10 @@ async fn adds_dependencies_to_target_component() -> Result<()> {
     project
         .cargo_component("add --target --path foo/baz foo:baz")
         .assert()
-        .stderr(contains("Added dependency `foo:baz` with version `*`"));
+        .stderr(contains("Added dependency `foo:baz` from path `foo/baz`"));
 
     let manifest = fs::read_to_string(project.root().join("Cargo.toml"))?;
-    assert!(contains(r#""foo:baz" = { path = "foo/baz", version = "*" }"#).eval(&manifest));
+    assert!(contains(r#""foo:baz" = { path = "foo/baz" }"#).eval(&manifest));
 
     Ok(())
 }


### PR DESCRIPTION
Add the `--path` flag to `cargo component add`, allowing dependencies to be resolved from local files. In this case, the version is defaulted to `*`.
