### PR TITLE
Implement generating target code for resources.

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -17,7 +17,7 @@ use warg_protocol::registry::PackageId;
 use wit_bindgen_rust_lib::to_rust_ident;
 use wit_component::DecodedWasm;
 use wit_parser::{
-    Function, Interface, Resolve, Type, TypeDef, TypeDefKind, TypeId, TypeOwner, WorldId,
+    Function, Handle, Interface, Resolve, Type, TypeDef, TypeDefKind, TypeId, TypeOwner, WorldId,
     WorldItem, WorldKey,
 };
 
@@ -491,8 +491,15 @@ impl<'a> SourceGenerator<'a> {
                 source.push('>');
             }
             TypeDefKind::Type(ty) => Self::print_type(resolve, ty, source, trie)?,
-            TypeDefKind::Resource | TypeDefKind::Handle(_) => {
-                todo!("implement resources support")
+            TypeDefKind::Handle(Handle::Own(id)) => {
+                Self::print_type_id(resolve, *id, source, trie)?
+            }
+            TypeDefKind::Handle(Handle::Borrow(id)) => {
+                source.push('&');
+                Self::print_type_id(resolve, *id, source, trie)?
+            }
+            TypeDefKind::Resource => {
+                bail!("unsupported anonymous resource type found in WIT package")
             }
             TypeDefKind::Unknown => unreachable!(),
         }

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -141,8 +141,12 @@ async fn it_targets_a_world() -> Result<()> {
         "1.2.3",
         r#"package foo:bar@1.2.3
 world foo {
-    import foo: func() -> string
-    export bar: func() -> string
+    resource file {
+        open: static func(path: string) -> file
+        path: func() -> string
+    }
+    import foo: func() -> file
+    export bar: func(file: borrow<file>) -> file
 }"#,
         true,
     )


### PR DESCRIPTION
This PR implements the missing support in generating code for the `--target` option of `cargo component new` when the targeted world exports items with owned and borrowed resources.