### PR TITLE
Add `--path` option to `wit add` command.

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -105,7 +105,14 @@ impl Serialize for Dependency {
                     .serialize(serializer)
                 }
             }
-            Self::Local(path) => path.serialize(serializer),
+            Self::Local(path) => {
+                #[derive(Serialize)]
+                struct Entry<'a> {
+                    path: &'a PathBuf,
+                }
+
+                Entry { path }.serialize(serializer)
+            }
         }
     }
 }

--- a/crates/wit/tests/add.rs
+++ b/crates/wit/tests/add.rs
@@ -155,3 +155,18 @@ async fn does_not_modify_manifest_for_dry_run() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn validate_add_from_path() -> Result<()> {
+    let project = Project::new("foo")?;
+
+    project
+        .wit("add --path foo/baz foo:baz")
+        .assert()
+        .stderr(contains("Added dependency `foo:baz` from path `foo/baz`"));
+
+    let manifest = fs::read_to_string(project.root().join("wit.toml"))?;
+    assert!(contains(r#""foo:baz" = { path = "foo/baz" }"#).eval(&manifest));
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a `--path` option to the `wit add` command, similar to how PR #113 added the option to `cargo component add`.

It also fixes the formatting such that dependencies that need an inline table are written with an inline table.