### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
+    - name: Configure sccache
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       shell: bash
-    - name: Build cargo-component
-      run: cargo build
-    - name: Test cargo-component
+    - name: Run all tests
       run: cargo test --all
 
   example:


### PR DESCRIPTION
This attempts to speed up CI by caching various rustc invocations.

CI is really slow because the tests repeatedly rebuild `wit-bindgen` for every
test project created for `cargo-component`.