### PR TITLE
Fix code generation for `flags`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 dependencies = [
  "serde",
 ]
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -2006,12 +2006,12 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
 ]
 
 [[package]]
@@ -2373,9 +2373,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "20b9b67e2ca7dd9e9f9285b759de30ff538aab981abaaf7bc9bd90b84a0126c3"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -2586,18 +2586,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2848,9 +2848,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
@@ -3171,9 +3171,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -3533,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3723,11 +3723,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3766,8 +3767,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86fe4c862e5d3d06d65ff0e9b5da8e84217af535bca6fc3acffed9eff0f5c2"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "bitflags 2.4.0",
  "wit-bindgen-rust-macro",
@@ -3776,8 +3776,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed17e12f4277a1de3a33ef68e4934bd10a9c295053f4de803b5c0ba856b4c08"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -3787,8 +3786,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6a165d93a825badf9c2db8c4033d76455807a4ab5f6890ccd01936d16b20ed"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "heck",
@@ -3801,8 +3799,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-lib"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e00b553c5b5fcdabe295cb1cdb369f76f72e8c626be1930e99bb01a4e7f4dc"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -3811,8 +3808,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d49b81b63fa30c3b13a559cd89dc3a721ccd94736a0b375cae718da5995d64"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ tokio = { version = "1.32.0", default-features = false, features = [
 tokio-util = "0.7.8"
 heck = "0.4.1"
 semver = "1.0.18"
-serde = { version = "1.0.183", features = ["derive"] }
+serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 indexmap = "2.0.0"
 url = { version = "2.4.0", features = ["serde"] }
@@ -91,7 +91,9 @@ bytes = "1.4.0"
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.29"
-wit-bindgen-rust-lib = "0.10.0"
-wit-bindgen-core = "0.10.0"
-wit-bindgen-rust = "0.10.0"
-wit-bindgen = "0.10.0"
+
+# TODO: Update on next release to not use git
+wit-bindgen-rust-lib = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-core = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -8,3 +8,7 @@ pub use cargo_component_macro::generate;
 // Re-export `wit_bindgen::rt` module for the generated code to use.
 #[doc(hidden)]
 pub use wit_bindgen::rt;
+
+// Re-export `wit_bindgen::bitflags` module for the generated code to use.
+#[doc(hidden)]
+pub use wit_bindgen::bitflags;

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -307,8 +307,8 @@ impl Config {
         let opts = Opts {
             exports,
             ownership: self.ownership,
-            runtime_path: Some("cargo_component_bindings::rt".to_string()),
-            bitflags_path: Some("cargo_component_bindings::bitflags".to_string()),
+            runtime_path: Some("::cargo_component_bindings::rt".to_string()),
+            bitflags_path: Some("::cargo_component_bindings::bitflags".to_string()),
             ..Default::default()
         };
 

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -308,6 +308,7 @@ impl Config {
             exports,
             ownership: self.ownership,
             runtime_path: Some("cargo_component_bindings::rt".to_string()),
+            bitflags_path: Some("cargo_component_bindings::bitflags".to_string()),
             ..Default::default()
         };
 

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -172,18 +172,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -251,9 +251,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -345,8 +345,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a86fe4c862e5d3d06d65ff0e9b5da8e84217af535bca6fc3acffed9eff0f5c2"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "bitflags 2.4.0",
  "wit-bindgen-rust-macro",
@@ -355,8 +354,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed17e12f4277a1de3a33ef68e4934bd10a9c295053f4de803b5c0ba856b4c08"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -366,8 +364,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6a165d93a825badf9c2db8c4033d76455807a4ab5f6890ccd01936d16b20ed"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "heck",
@@ -380,8 +377,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-lib"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e00b553c5b5fcdabe295cb1cdb369f76f72e8c626be1930e99bb01a4e7f4dc"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -390,8 +386,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d49b81b63fa30c3b13a559cd89dc3a721ccd94736a0b375cae718da5995d64"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -367,7 +367,11 @@ fn empty_world_with_dep_valid() -> Result<()> {
             package foo:bar
 
             world the-world {
-                export hello: func()
+                flags foo {
+                    bar
+                }
+        
+                export hello: func() -> foo
             }
         ",
     )?;
@@ -376,12 +380,12 @@ fn empty_world_with_dep_valid() -> Result<()> {
         project.root().join("src/lib.rs"),
         "
             cargo_component_bindings::generate!();
-            use bindings::TheWorld;
+            use bindings::{TheWorld, Foo};
             struct Component;
 
             impl TheWorld for Component {
-                fn hello() {
-                    todo!()
+                fn hello() -> Foo {
+                    Foo::BAR
                 }
             }
         ",


### PR DESCRIPTION
This PR updates dependencies and `wit-bindgen` to a commit that has a fix for specifying the path to the `bitflags` crate re-export, allowing `cargo-component` targets to contain `flags` types.

Updated an existing test to cover the use of the `flags` type.

Fixes #119.