### PR TITLE
Remove implicit versioning in WIT resolves.

### DIFF
--- a/crates/wit/src/lib.rs
+++ b/crates/wit/src/lib.rs
@@ -244,13 +244,6 @@ async fn build_wit_package(
     let (mut resolve, package) = parse_wit_package(dir, &dependencies)?;
 
     let pkg = &mut resolve.packages[package];
-    if pkg.name.version.is_some() {
-        bail!(
-            "package parsed from `{dir}` has an explicit version",
-            dir = dir.display()
-        );
-    }
-
     let id = format!("{ns}:{name}", ns = pkg.name.namespace, name = pkg.name.name).parse()?;
 
     let bytes = wit_component::encode(&resolve, package)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@ async fn encode_target_world(
                 ),
             )?;
 
-            let encoded = encoder.encode(None)?;
+            let encoded = encoder.encode()?;
             fs::create_dir_all(&output_dir).with_context(|| {
                 format!(
                     "failed to create output directory `{path}`",


### PR DESCRIPTION
This PR changes `cargo-component` so that it no longer implicitly sets the version numbers on any local WIT definitions.

Closes #129.
Closes #111.