### PR TITLE
Add registry metadata to published components.

### DIFF
--- a/crates/wit/src/commands/add.rs
+++ b/crates/wit/src/commands/add.rs
@@ -1,9 +1,4 @@
-use std::path::PathBuf;
-
-use crate::{
-    config::{Config, CONFIG_FILE_NAME},
-    resolve_dependencies,
-};
+use crate::config::{Config, CONFIG_FILE_NAME};
 use anyhow::{bail, Context, Result};
 use cargo_component_core::{
     command::CommonOptions,
@@ -13,6 +8,7 @@ use cargo_component_core::{
 };
 use clap::Args;
 use semver::VersionReq;
+use std::path::PathBuf;
 use warg_protocol::registry::PackageId;
 
 async fn resolve_version(
@@ -126,16 +122,6 @@ impl AddCommand {
                 config
                     .dependencies
                     .insert(id.clone(), Dependency::Package(package));
-
-                // Resolve all dependencies to ensure that the lockfile is up to date.
-                resolve_dependencies(
-                    &config,
-                    &config_path,
-                    &warg_config,
-                    &terminal,
-                    !self.dry_run,
-                )
-                .await?;
 
                 format!(
                     "dependency `{id}` with version `{version}`{dry_run}",

--- a/crates/wit/src/config.rs
+++ b/crates/wit/src/config.rs
@@ -62,6 +62,13 @@ impl ConfigBuilder {
             version: self.version.unwrap_or_else(|| Version::new(0, 1, 0)),
             dependencies: Default::default(),
             registries: self.registries,
+            authors: Default::default(),
+            categories: Default::default(),
+            description: None,
+            license: None,
+            documentation: None,
+            homepage: None,
+            repository: None,
         }
     }
 }
@@ -72,9 +79,32 @@ pub struct Config {
     /// The current package version.
     pub version: Version,
     /// The package dependencies.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub dependencies: HashMap<PackageId, Dependency>,
     /// The registries to use for sourcing packages.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub registries: HashMap<String, Url>,
+    /// The authors of the package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+    /// The categories of the package.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<String>,
+    /// The package description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The package license.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+    /// The package documentation URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+    /// The package homepage URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+    /// The package repository URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
 }
 
 impl Config {

--- a/crates/wit/src/lib.rs
+++ b/crates/wit/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
 use warg_client::storage::{ContentStorage, PublishEntry, PublishInfo};
 use warg_crypto::signing::PrivateKey;
 use warg_protocol::registry::PackageId;
+use wasm_metadata::{Link, LinkType, RegistryMetadata};
 use wit_component::DecodedWasm;
 use wit_parser::{PackageName, Resolve, UnresolvedPackage};
 
@@ -273,6 +274,56 @@ struct PublishOptions<'a> {
     dry_run: bool,
 }
 
+fn add_registry_metadata(config: &Config, bytes: &[u8]) -> Result<Vec<u8>> {
+    let mut metadata = RegistryMetadata::default();
+    if !config.authors.is_empty() {
+        metadata.set_authors(Some(config.authors.clone()));
+    }
+
+    if !config.categories.is_empty() {
+        metadata.set_categories(Some(config.categories.clone()));
+    }
+
+    metadata.set_description(config.description.clone());
+
+    // TODO: registry metadata should have keywords
+    // if !package.keywords.is_empty() {
+    //     metadata.set_keywords(Some(package.keywords.clone()));
+    // }
+
+    metadata.set_license(config.license.clone());
+
+    let mut links = Vec::new();
+    if let Some(docs) = &config.documentation {
+        links.push(Link {
+            ty: LinkType::Documentation,
+            value: docs.clone(),
+        });
+    }
+
+    if let Some(homepage) = &config.homepage {
+        links.push(Link {
+            ty: LinkType::Homepage,
+            value: homepage.clone(),
+        });
+    }
+
+    if let Some(repo) = &config.repository {
+        links.push(Link {
+            ty: LinkType::Repository,
+            value: repo.clone(),
+        });
+    }
+
+    if !links.is_empty() {
+        metadata.set_links(Some(links));
+    }
+
+    metadata
+        .add_to_wasm(bytes)
+        .context("failed to add registry metadata to component")
+}
+
 async fn publish_wit_package(options: PublishOptions<'_>, terminal: &Terminal) -> Result<()> {
     let (id, bytes) = build_wit_package(
         options.config,
@@ -287,6 +338,7 @@ async fn publish_wit_package(options: PublishOptions<'_>, terminal: &Terminal) -
         return Ok(());
     }
 
+    let bytes = add_registry_metadata(options.config, &bytes)?;
     let id = options.package.unwrap_or(&id);
     let client = create_client(options.warg_config, options.url, terminal)?;
 

--- a/crates/wit/tests/publish.rs
+++ b/crates/wit/tests/publish.rs
@@ -1,8 +1,14 @@
+use std::fs;
+
 use crate::support::*;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use assert_cmd::prelude::*;
 use predicates::str::contains;
-use warg_client::FileSystemClient;
+use semver::Version;
+use toml_edit::{value, Array};
+use warg_client::{Client, FileSystemClient};
+use warg_protocol::registry::PackageId;
+use wasm_metadata::LinkType;
 
 mod support;
 
@@ -70,6 +76,110 @@ async fn it_does_a_dry_run_publish() -> Result<()> {
         .unwrap_err()
         .to_string()
         .contains("package `baz:qux` does not exist"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_publishes_with_registry_metadata() -> Result<()> {
+    let root = create_root()?;
+    let (_server, config) = spawn_server(&root).await?;
+    config.write_to_file(&root.join("warg-config.json"))?;
+
+    let authors = ["Jane Doe <jane@example.com>"];
+    let categories = ["wasm"];
+    let description = "A test package";
+    let license = "Apache-2.0";
+    let documentation = "https://example.com/docs";
+    let homepage = "https://example.com/home";
+    let repository = "https://example.com/repo";
+
+    let project = Project::with_root(&root, "foo", "")?;
+    project.file("baz.wit", "package baz:qux\n")?;
+
+    project.update_manifest(|mut doc| {
+        doc["authors"] = value(Array::from_iter(authors));
+        doc["categories"] = value(Array::from_iter(categories));
+        doc["description"] = value(description);
+        doc["license"] = value(license);
+        doc["documentation"] = value(documentation);
+        doc["homepage"] = value(homepage);
+        doc["repository"] = value(repository);
+        Ok(doc)
+    })?;
+
+    project
+        .wit("publish --init")
+        .env("WIT_PUBLISH_KEY", test_signing_key())
+        .assert()
+        .stderr(contains("Published package `baz:qux` v0.1.0"))
+        .success();
+
+    let client = Client::new_with_config(None, &config)?;
+    let download = client
+        .download_exact(&PackageId::new("baz:qux")?, &Version::parse("0.1.0")?)
+        .await?;
+
+    let bytes = fs::read(&download.path).with_context(|| {
+        format!(
+            "failed to read downloaded package `{path}`",
+            path = download.path.display()
+        )
+    })?;
+
+    let metadata = wasm_metadata::RegistryMetadata::from_wasm(&bytes)
+        .with_context(|| {
+            format!(
+                "failed to parse registry metadata from `{path}`",
+                path = download.path.display()
+            )
+        })?
+        .expect("missing registry metadata");
+
+    assert_eq!(
+        metadata.get_authors().expect("missing authors").as_slice(),
+        authors
+    );
+    assert_eq!(
+        metadata
+            .get_categories()
+            .expect("missing categories")
+            .as_slice(),
+        categories
+    );
+    assert_eq!(
+        metadata.get_description().expect("missing description"),
+        description
+    );
+    assert_eq!(metadata.get_license().expect("missing license"), license);
+
+    let links = metadata.get_links().expect("missing links");
+    assert_eq!(links.len(), 3);
+
+    assert_eq!(
+        links
+            .iter()
+            .find(|link| link.ty == LinkType::Documentation)
+            .expect("missing documentation")
+            .value,
+        documentation
+    );
+    assert_eq!(
+        links
+            .iter()
+            .find(|link| link.ty == LinkType::Homepage)
+            .expect("missing homepage")
+            .value,
+        homepage
+    );
+    assert_eq!(
+        links
+            .iter()
+            .find(|link| link.ty == LinkType::Repository)
+            .expect("missing repository")
+            .value,
+        repository
+    );
 
     Ok(())
 }

--- a/crates/wit/tests/support/mod.rs
+++ b/crates/wit/tests/support/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use toml_edit::Document;
 use warg_crypto::signing::PrivateKey;
 use warg_server::{policy::content::WasmContentPolicy, Config, Server};
 use wasmparser::{Chunk, Encoding, Parser, Payload, Validator, WasmFeatures};
@@ -185,6 +186,13 @@ impl Project {
         let mut cmd = wit(cmd);
         cmd.current_dir(&self.root);
         cmd
+    }
+
+    pub fn update_manifest(&self, f: impl FnOnce(Document) -> Result<Document>) -> Result<()> {
+        let manifest_path = self.root.join("wit.toml");
+        let manifest = fs::read_to_string(&manifest_path)?;
+        fs::write(manifest_path, f(manifest.parse()?)?.to_string())?;
+        Ok(())
     }
 }
 

--- a/crates/wit/tests/update.rs
+++ b/crates/wit/tests/update.rs
@@ -51,6 +51,12 @@ async fn update_without_changes_is_a_noop() -> Result<()> {
         .success();
 
     project
+        .wit("build")
+        .assert()
+        .success()
+        .stderr(contains("Created package `baz.wasm`"));
+
+    project
         .wit("update")
         .assert()
         .success()
@@ -81,6 +87,12 @@ async fn test_update_without_compatible_changes_is_a_noop() -> Result<()> {
         .assert()
         .stderr(contains("Added dependency `foo:bar` with version `0.1.0"))
         .success();
+
+    project
+        .wit("build")
+        .assert()
+        .success()
+        .stderr(contains("Created package `baz.wasm`"));
 
     fs::write(
         root.join("bar/wit.toml"),
@@ -130,6 +142,12 @@ async fn update_with_compatible_changes() -> Result<()> {
         .assert()
         .stderr(contains("Added dependency `foo:bar` with version `1.0.0"))
         .success();
+
+    project
+        .wit("build")
+        .assert()
+        .success()
+        .stderr(contains("Created package `baz.wasm`"));
 
     fs::write(
         root.join("bar/wit.toml"),
@@ -182,6 +200,12 @@ async fn update_with_compatible_changes_is_noop_for_dryrun() -> Result<()> {
         .assert()
         .stderr(contains("Added dependency `foo:bar` with version `1.0.0"))
         .success();
+
+    project
+        .wit("build")
+        .assert()
+        .success()
+        .stderr(contains("Created package `baz.wasm`"));
 
     fs::write(
         root.join("bar/wit.toml"),

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -180,6 +180,7 @@ impl PublishCommand {
         }
 
         let options = PublishOptions {
+            package,
             registry_url,
             init: self.init,
             id,


### PR DESCRIPTION
This PR adds registry metadata to components published to a registry with
`cargo component publish` and `wit publish`.