### PR TITLE
Fix toposort for decoded binary WIT packages.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,7 @@ clap = { version = "4.4.1", features = ["derive"] }
 toml_edit = { version = "0.19.14", features = ["serde"] }
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
-tokio = { version = "1.32.0", default-features = false, features = [
-    "macros",
-    "rt-multi-thread",
-] }
+tokio = { version = "1.32.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 tokio-util = "0.7.8"
 heck = "0.4.1"
 semver = "1.0.18"
@@ -91,7 +88,6 @@ bytes = "1.4.0"
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.29"
-
 wit-bindgen-rust-lib = "0.11.0"
 wit-bindgen-core = "0.11.0"
 wit-bindgen-rust = "0.11.0"


### PR DESCRIPTION
Previously, the toposort performed for WIT dependencies would skip visiting any of the dependencies of decoded binary packages because it was assumed that it was unnecessary due to the fact the dependency information was encoded in the package.

However, wit-parser doesn't merge interfaces unless they have identical definitions (see https://github.com/bytecodealliance/wasm-tools/issues/1191).

This means that we run into problems when a decoded binary package is merged *before* a dependency that contains the full (or otherwise disjoint) definition of the interface.

To work around this issue, users should be able to add an explicit dependency on any transitive dependencies so that they get merged first.

For that to work, we need to visit any dependencies on decoded binary packages as well, which is what this PR implements.

This also contains some cleanup from the previous work to not muck with package versions when merging WIT resolves.