### PR TITLE
Use a default target path of `wit`.

### DIFF
--- a/docs/design/registries.md
+++ b/docs/design/registries.md
@@ -321,9 +321,6 @@ version = "1.2.3"
 [package.metadata.component]
 package = "my-org:my-component"
 
-[package.metadata.component.target]
-path = "wit"
-
 [package.metadata.component.target.dependencies]
 "wasi:cli" = "1.2.3"
 

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -310,18 +310,18 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
+checksum = "1ba64e81215916eaeb48fee292f29401d69235d62d8b8fd92a7b2844ec5ae5f7"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac8d3bcbbb5081489f35966b86d127596e9cdacfb3824b79f43344662226178"
+checksum = "08dc59d1fa569150851542143ca79438ca56845ccb31696c70225c638e063471"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad71036aada3f6b09251546e97e4f4f176dd6b41cf6fa55e7e0f65e86aec319a"
+checksum = "e986b010f47fcce49cf8ea5d5f9e5d2737832f12b53ae8ae785bbe895d0877bf"
 dependencies = [
  "indexmap",
  "semver",
@@ -344,8 +344,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.10.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a3e8e965dc50e6eb4410d9a11720719fadc6a1713803ea5f3be390b81c8279"
 dependencies = [
  "bitflags 2.4.0",
  "wit-bindgen-rust-macro",
@@ -353,8 +354,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.10.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77255512565dfbd0b61de466e854918041d1da53c7bc049d6188c6e02643dc1e"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -363,8 +365,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.10.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c60e6ea8598d1380e792f13d557007834f0fb799fea6503408cbc5debb4ae"
 dependencies = [
  "anyhow",
  "heck",
@@ -376,8 +379,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-lib"
-version = "0.10.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fb7a43c7dc28b0b727d6ae01bf369981229b7539e768fba2b7a4df13feeeb"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -385,8 +389,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.10.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#749c01697bb3b11daeae4225789e14b765dcf839"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cea5ed784da06da0e55836a6c160e7502dbe28771c2368a595e8606243bf22"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -399,14 +404,16 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9eb6179c5a26adc38fa5a22e263e7a3812c6777ca2e75d1717fd3789f82b64"
+checksum = "66d9f2d16dd55d1a372dcfd4b7a466ea876682a5a3cb97e71ec9eef04affa876"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
  "indexmap",
  "log",
+ "serde",
+ "serde_json",
  "wasm-encoder",
  "wasm-metadata",
  "wasmparser",
@@ -415,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d6926af931f285e206ea71f9b67681f00a65d79097f81da7f9f285de006ba2"
+checksum = "61e8b849bea13cc2315426b16efe6eb6813466d78f5fde69b0bb150c9c40e0dc"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -12,9 +12,6 @@ cargo-component-bindings = { path = "../crates/bindings" }
 [package.metadata.component]
 package = "example:component"
 
-[package.metadata.component.target]
-path = "wit"
-
 [package.metadata.component.dependencies]
 
 [workspace]

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, generator::SourceGenerator, metadata};
+use crate::{config::Config, generator::SourceGenerator, metadata, metadata::DEFAULT_WIT_DIR};
 use anyhow::{bail, Context, Result};
 use cargo_component_core::{
     command::CommonOptions,
@@ -257,8 +257,8 @@ impl NewCommand {
         ));
 
         if !self.is_command() {
-            component["target"] = match target.as_ref() {
-                Some((resolution, world)) => match world {
+            if let Some((resolution, world)) = target.as_ref() {
+                component["target"] = match world {
                     Some(world) => value(format!(
                         "{id}/{world}@{version}",
                         id = resolution.id,
@@ -269,13 +269,8 @@ impl NewCommand {
                         id = resolution.id,
                         version = resolution.version
                     )),
-                },
-                None => {
-                    let mut target_deps = Table::new();
-                    target_deps["path"] = value("wit");
-                    Item::Table(target_deps)
-                }
-            };
+                };
+            }
         }
 
         component["dependencies"] = Item::Table(Table::new());
@@ -402,7 +397,7 @@ impl Guest for Component {
             return Ok(());
         }
 
-        let wit_path = out_dir.join("wit");
+        let wit_path = out_dir.join(DEFAULT_WIT_DIR);
         fs::create_dir(&wit_path).with_context(|| {
             format!(
                 "failed to create targets directory `{wit_path}`",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,7 @@ pub async fn run_cargo_command(
     Ok(outputs)
 }
 
-fn last_modified_time(path: impl AsRef<Path>) -> Result<SystemTime> {
-    let path = path.as_ref();
+fn last_modified_time(path: &Path) -> Result<SystemTime> {
     path.metadata()
         .with_context(|| {
             format!(
@@ -379,13 +378,7 @@ async fn encode_target_world(
                 )
             })?;
 
-            let world = resolution
-                .metadata
-                .section
-                .target
-                .as_ref()
-                .and_then(|t| t.world())
-                .unwrap_or("");
+            let world = resolution.metadata.section.target.world().unwrap_or("");
 
             fs::write(&world_path, world).with_context(|| {
                 format!(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -58,12 +58,7 @@ impl<'a> PackageDependencyResolution<'a> {
         lock_file: Option<LockFileResolver<'_>>,
         network_allowed: bool,
     ) -> Result<DependencyResolutionMap> {
-        let target_deps = metadata
-            .section
-            .target
-            .as_ref()
-            .map(|t| t.dependencies())
-            .unwrap_or_default();
+        let target_deps = metadata.section.target.dependencies();
 
         let mut resolver = DependencyResolver::new(
             config.warg(),

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -224,13 +224,14 @@ fn it_builds_with_local_wit_deps() -> Result<()> {
     let project = Project::new("foo")?;
     project.update_manifest(|mut doc| {
         redirect_bindings_crate(&mut doc);
-        doc["package"]["metadata"]["component"]["target"]["path"] = value("wit");
         let mut dependencies = Table::new();
         dependencies["foo:bar"]["path"] = value("wit/deps/foo-bar");
         dependencies["bar:baz"]["path"] = value("wit/deps/bar-baz/qux.wit");
         dependencies["baz:qux"]["path"] = value("wit/deps/foo-bar/deps/baz-qux/qux.wit");
-        doc["package"]["metadata"]["component"]["target"]["dependencies"] =
-            Item::Table(dependencies);
+
+        let target =
+            doc["package"]["metadata"]["component"]["target"].or_insert(Item::Table(Table::new()));
+        target["dependencies"] = Item::Table(dependencies);
         Ok(doc)
     })?;
 


### PR DESCRIPTION
This PR makes `target.path` in the metadata default to a `wit` directory, if present.

This makes the `wit` directory a canonical directory, much like `src` is for source code.

Users may still override the path to find their local target definition.

Closes #134.