### PR TITLE
Add an `adapter` setting to `Cargo.toml`.

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -220,6 +220,8 @@ pub struct ComponentSection {
     pub package: Option<PackageId>,
     /// The world targeted by the component.
     pub target: Target,
+    /// The path to the WASI adapter to use.
+    pub adapter: Option<PathBuf>,
     /// The dependencies of the component.
     pub dependencies: HashMap<PackageId, Dependency>,
     /// The registries to use for the component.


### PR DESCRIPTION
This PR adds a `package.metadata.component.adapter` field to `Cargo.toml` which is the path to the WASI module adapter to use.

If present, the specified file is used to adapt WASI preview1 to preview2.

If not present, the built-in WASI module adapter is used instead.

The intention with this change is to allow users control over how WASI is adapted in cases where the built-in adapter is not the desired one to use.