### PR TITLE
Make the adapter path in `Cargo.toml` relative to the manifest dir.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,8 +498,8 @@ fn create_component(
     )?;
 
     let encoder = ComponentEncoder::default()
-        .adapter("wasi_snapshot_preview1", &adapter_bytes(metadata, binary)?)?
         .module(&module)?
+        .adapter("wasi_snapshot_preview1", &adapter_bytes(metadata, binary)?)?
         .validate(true);
 
     let mut producers = wasm_metadata::Producers::empty();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -303,6 +303,10 @@ impl ComponentMetadata {
             }
         }
 
+        if let Some(adapter) = section.adapter.as_mut() {
+            *adapter = manifest_dir.join(adapter.as_path());
+        }
+
         Ok(Some(Self {
             name: package.name.clone(),
             version: package.version.clone(),

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -733,9 +733,7 @@ fn it_builds_with_adapter() -> Result<()> {
     project
         .cargo_component("build")
         .assert()
-        .stderr(contains(
-            "error: failed to read module adapter `not-a-valid-path`",
-        ))
+        .stderr(contains("error: failed to read module adapter"))
         .failure();
 
     let project = Project::new("foo")?;


### PR DESCRIPTION
This PR fixes a bug where the `adapter` setting in `Cargo.toml` wasn't being treated as relative to the manifest directory.

This PR also improves the diagnostics relating to a mismatched preview1 adapter by changing the order in which we call `module` and `adapter` on `ComponentEncoder`.