### PR TITLE
Add GitHub actions for publishing crates.

### DIFF
--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -1,0 +1,23 @@
+# The purpose of this workflow is to publish the workspace's crates
+# whenever a tag is created. This baiscally boils down to running
+# `scripts/publish.rs` at the right time.
+
+name: "Publish to crates.io"
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  publish:
+    if: github.repository == 'bytecodealliance/cargo-component'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: |
+        rustc ci/publish.rs
+        ./publish publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-to-crates-io.yml
+++ b/.github/workflows/publish-to-crates-io.yml
@@ -1,5 +1,5 @@
 # The purpose of this workflow is to publish the workspace's crates
-# whenever a tag is created. This baiscally boils down to running
+# whenever a tag is created. This basically boils down to running
 # `scripts/publish.rs` at the right time.
 
 name: "Publish to crates.io"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-bindings"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo-component-macro",
  "wit-bindgen",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "wit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "wit"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+readme = "README.md"
 
 [workspace.package]
 version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
@@ -59,8 +59,8 @@ members = ["crates/bindings", "crates/macro", "crates/core", "crates/wit"]
 exclude = ["target/tests"]
 
 [workspace.dependencies]
-cargo-component-core = { path = "crates/core", version = "0.1.0" }
-cargo-component-macro = { path = "crates/macro", version = "0.1.0" }
+cargo-component-core = { path = "crates/core", version = "0.2.0" }
+cargo-component-macro = { path = "crates/macro", version = "0.2.0" }
 warg-protocol = "0.1.0"
 warg-crypto = "0.1.0"
 warg-client = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -38,12 +38,8 @@ may cause build errors for existing component projects.
 To install the `cargo component` subcommand, run the following command:
 
 ```
-cargo install --git https://github.com/bytecodealliance/cargo-component --locked cargo-component
+cargo install cargo-component
 ```
-
-The [currently published crate](https://crates.io/crates/cargo-component)
-on crates.io is a nonfunctional placeholder and these instructions will be
-updated to install the crates.io package once a proper release is made.
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -268,9 +268,8 @@ for other IDEs.
 ## Contributing to `cargo component`
 
 `cargo component` is a [Bytecode Alliance](https://bytecodealliance.org/)
-project, and follows
-the Bytecode Alliance's [Code of Conduct](CODE_OF_CONDUCT.md) and
-[Organizational Code of Conduct](ORG_CODE_OF_CONDUCT.md).
+project, and follows the Bytecode Alliance's [Code of Conduct](CODE_OF_CONDUCT.md)
+and [Organizational Code of Conduct](ORG_CODE_OF_CONDUCT.md).
 
 ### Getting the Code
 
@@ -306,14 +305,10 @@ command. This is checked on CI.
 The CI for the `cargo component` repository is relatively significant. It tests
 changes on Windows, macOS, and Linux.
 
-It also performs a "dry run" of the release process to ensure that release
-binaries can be built and are ready to be published (_coming soon_).
-
-### Publishing (_coming soon_)
+### Publishing
 
 Publication of this crate is entirely automated via CI. A publish happens
 whenever a tag is pushed to the repository, so to publish a new version you'll
-want to make a PR that bumps the version numbers (see the `bump.rs` scripts in
-the root of the repository), merge the PR, then tag the PR and push the tag.
-That should trigger all that's necessary to publish all the crates and binaries
-to crates.io.
+want to make a PR that bumps the version numbers (see the `ci/publish.rs` 
+script), merge the PR, then tag the PR and push the tag. That should trigger 
+all that's necessary to publish all the crates and binaries to crates.io.

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -1,0 +1,406 @@
+//! Helper script to publish the warg suites of crates
+//!
+//! * `./publish bump` - bump crate versions in-tree
+//! * `./publish verify` - verify crates can be published to crates.io
+//! * `./publish publish` - actually publish crates to crates.io
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+// note that this list must be topologically sorted by dependencies
+const CRATES_TO_PUBLISH: &[&str] = &[
+    "cargo-component-macro",
+    "cargo-component-bindings",
+    "cargo-component-core",
+    //"wit",
+    "cargo-component",
+];
+
+// Anything **not** mentioned in this array is required to have an `=a.b.c`
+// dependency requirement on it to enable breaking api changes even in "patch"
+// releases since everything not mentioned here is just an organizational detail
+// that no one else should rely on.
+const PUBLIC_CRATES: &[&str] = &[
+    "cargo-component-macro",
+    "cargo-component-bindings",
+    "cargo-component-core",
+    //"wit",
+    "cargo-component",
+];
+
+struct Workspace {
+    version: String,
+}
+
+struct Crate {
+    manifest: PathBuf,
+    name: String,
+    version: String,
+    publish: bool,
+}
+
+fn main() {
+    let mut crates = Vec::new();
+    let root = read_crate(None, "./Cargo.toml".as_ref());
+    let ws = Workspace {
+        version: root.version.clone(),
+    };
+    crates.push(root);
+    find_crates("crates".as_ref(), &ws, &mut crates);
+
+    let pos = CRATES_TO_PUBLISH
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (*c, i))
+        .collect::<HashMap<_, _>>();
+    crates.sort_by_key(|krate| pos.get(&krate.name[..]));
+
+    match &env::args().nth(1).expect("must have one argument")[..] {
+        name @ "bump" | name @ "bump-patch" => {
+            for krate in crates.iter() {
+                bump_version(&krate, &crates, name == "bump-patch");
+            }
+            // update the lock file
+            assert!(Command::new("cargo")
+                .arg("fetch")
+                .status()
+                .unwrap()
+                .success());
+        }
+
+        "publish" => {
+            // We have so many crates to publish we're frequently either
+            // rate-limited or we run into issues where crates can't publish
+            // successfully because they're waiting on the index entries of
+            // previously-published crates to propagate. This means we try to
+            // publish in a loop and we remove crates once they're successfully
+            // published. Failed-to-publish crates get enqueued for another try
+            // later on.
+            for _ in 0..10 {
+                crates.retain(|krate| !publish(krate));
+
+                if crates.is_empty() {
+                    break;
+                }
+
+                println!(
+                    "{} crates failed to publish, waiting for a bit to retry",
+                    crates.len(),
+                );
+                thread::sleep(Duration::from_secs(40));
+            }
+
+            assert!(crates.is_empty(), "failed to publish all crates");
+
+            println!("");
+            println!("===================================================================");
+            println!("");
+            println!("Don't forget to push a git tag for this release!");
+            println!("");
+            println!("    $ git tag vX.Y.Z");
+            println!("    $ git push git@github.com:bytecodealliance/cargo-component.git vX.Y.Z");
+        }
+
+        "verify" => {
+            verify(&crates);
+        }
+
+        s => panic!("unknown command: {}", s),
+    }
+}
+
+fn find_crates(dir: &Path, ws: &Workspace, dst: &mut Vec<Crate>) {
+    if dir.join("Cargo.toml").exists() {
+        let krate = read_crate(Some(ws), &dir.join("Cargo.toml"));
+        if !krate.publish || CRATES_TO_PUBLISH.iter().any(|c| krate.name == *c) {
+            dst.push(krate);
+        } else {
+            panic!("failed to find {:?} in whitelist or blacklist", krate.name);
+        }
+    }
+
+    for entry in dir.read_dir().unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_type().unwrap().is_dir() {
+            find_crates(&entry.path(), ws, dst);
+        }
+    }
+}
+
+fn read_crate(ws: Option<&Workspace>, manifest: &Path) -> Crate {
+    let mut name = None;
+    let mut version = None;
+    let mut publish = true;
+    for line in fs::read_to_string(manifest).unwrap().lines() {
+        if name.is_none() && line.starts_with("name = \"") {
+            name = Some(
+                line.replace("name = \"", "")
+                    .replace("\"", "")
+                    .trim()
+                    .to_string(),
+            );
+        }
+        if version.is_none() && line.starts_with("version = \"") {
+            version = Some(
+                line.replace("version = \"", "")
+                    .replace("\"", "")
+                    .trim()
+                    .to_string(),
+            );
+        }
+        if let Some(ws) = ws {
+            if version.is_none() && (line.starts_with("version.workspace = true") || line.starts_with("version = { workspace = true }")) {
+                version = Some(ws.version.clone());
+            }
+        }
+        if line.starts_with("publish = false") {
+            publish = false;
+        }
+    }
+    let name = name.unwrap();
+    let version = version.unwrap();
+    Crate {
+        manifest: manifest.to_path_buf(),
+        name,
+        version,
+        publish,
+    }
+}
+
+fn bump_version(krate: &Crate, crates: &[Crate], patch: bool) {
+    let contents = fs::read_to_string(&krate.manifest).unwrap();
+    let next_version = |krate: &Crate| -> String {
+        if CRATES_TO_PUBLISH.contains(&&krate.name[..]) {
+            bump(&krate.version, patch)
+        } else {
+            krate.version.clone()
+        }
+    };
+
+    let mut new_manifest = String::new();
+    let mut is_deps = false;
+    for line in contents.lines() {
+        let mut rewritten = false;
+        if !is_deps && line.starts_with("version =") {
+            if CRATES_TO_PUBLISH.contains(&&krate.name[..]) {
+                println!(
+                    "bump `{}` {} => {}",
+                    krate.name,
+                    krate.version,
+                    next_version(krate),
+                );
+                new_manifest.push_str(&line.replace(&krate.version, &next_version(krate)));
+                rewritten = true;
+            }
+        }
+
+        is_deps = if line.starts_with("[") {
+            line.contains("dependencies")
+        } else {
+            is_deps
+        };
+
+        for other in crates {
+            // If `other` isn't a published crate then it's not going to get a
+            // bumped version so we don't need to update anything in the
+            // manifest.
+            if !other.publish {
+                continue;
+            }
+            if !is_deps || !line.starts_with(&format!("{} ", other.name)) {
+                continue;
+            }
+            if !line.contains(&other.version) {
+                if !line.contains("version =") || !krate.publish {
+                    continue;
+                }
+                panic!(
+                    "{:?} has a dep on {} but doesn't list version {}",
+                    krate.manifest, other.name, other.version
+                );
+            }
+            if krate.publish {
+                if PUBLIC_CRATES.contains(&other.name.as_str()) {
+                    assert!(
+                        !line.contains("\"="),
+                        "{} should not have an exact version requirement on {}",
+                        krate.name,
+                        other.name
+                    );
+                } else {
+                    assert!(
+                        line.contains("\"="),
+                        "{} should have an exact version requirement on {}",
+                        krate.name,
+                        other.name
+                    );
+                }
+            }
+            rewritten = true;
+            new_manifest.push_str(&line.replace(&other.version, &next_version(other)));
+            break;
+        }
+        if !rewritten {
+            new_manifest.push_str(line);
+        }
+        new_manifest.push_str("\n");
+    }
+    fs::write(&krate.manifest, new_manifest).unwrap();
+}
+
+/// Performs a major version bump increment on the semver version `version`.
+///
+/// This function will perform a semver-major-version bump on the `version`
+/// specified. This is used to calculate the next version of a crate in this
+/// repository since we're currently making major version bumps for all our
+/// releases. This may end up getting tweaked as we stabilize crates and start
+/// doing more minor/patch releases, but for now this should do the trick.
+fn bump(version: &str, patch_bump: bool) -> String {
+    let mut iter = version.split('.').map(|s| s.parse::<u32>().unwrap());
+    let major = iter.next().expect("major version");
+    let minor = iter.next().expect("minor version");
+    let patch = iter.next().expect("patch version");
+
+    if patch_bump {
+        return format!("{}.{}.{}", major, minor, patch + 1);
+    }
+    if major != 0 {
+        format!("{}.0.0", major + 1)
+    } else if minor != 0 {
+        format!("0.{}.0", minor + 1)
+    } else {
+        format!("0.0.{}", patch + 1)
+    }
+}
+
+fn publish(krate: &Crate) -> bool {
+    if !CRATES_TO_PUBLISH.iter().any(|s| *s == krate.name) {
+        return true;
+    }
+
+    // First make sure the crate isn't already published at this version. This
+    // script may be re-run and there's no need to re-attempt previous work.
+    let output = Command::new("curl")
+        .arg(&format!("https://crates.io/api/v1/crates/{}", krate.name))
+        .output()
+        .expect("failed to invoke `curl`");
+    if output.status.success()
+        && String::from_utf8_lossy(&output.stdout)
+            .contains(&format!("\"newest_version\":\"{}\"", krate.version))
+    {
+        println!(
+            "skip publish {} because {} is latest version",
+            krate.name, krate.version,
+        );
+        return true;
+    }
+
+    let status = Command::new("cargo")
+        .arg("publish")
+        .current_dir(krate.manifest.parent().unwrap())
+        .arg("--no-verify")
+        .status()
+        .expect("failed to run cargo");
+    if !status.success() {
+        println!("FAIL: failed to publish `{}`: {}", krate.name, status);
+        return false;
+    }
+
+    // After we've published then make sure that the `wasmtime-publish` group is
+    // added to this crate for future publications. If it's already present
+    // though we can skip the `cargo owner` modification.
+    let output = Command::new("curl")
+        .arg(&format!(
+            "https://crates.io/api/v1/crates/{}/owners",
+            krate.name
+        ))
+        .output()
+        .expect("failed to invoke `curl`");
+    if output.status.success()
+        && String::from_utf8_lossy(&output.stdout).contains("wasmtime-publish")
+    {
+        println!(
+            "wasmtime-publish already listed as an owner of {}",
+            krate.name
+        );
+        return true;
+    }
+
+    // Note that the status is ignored here. This fails most of the time because
+    // the owner is already set and present, so we only want to add this to
+    // crates which haven't previously been published.
+    let status = Command::new("cargo")
+        .arg("owner")
+        .arg("-a")
+        .arg("github:bytecodealliance:wasmtime-publish")
+        .arg(&krate.name)
+        .status()
+        .expect("failed to run cargo");
+    if !status.success() {
+        panic!(
+            "FAIL: failed to add wasmtime-publish as owner `{}`: {}",
+            krate.name, status
+        );
+    }
+
+    true
+}
+
+// Verify the current tree is publish-able to crates.io. The intention here is
+// that we'll run `cargo package` on everything which verifies the build as-if
+// it were published to crates.io. This requires using an incrementally-built
+// directory registry generated from `cargo vendor` because the versions
+// referenced from `Cargo.toml` may not exist on crates.io.
+fn verify(crates: &[Crate]) {
+    drop(fs::remove_dir_all(".cargo"));
+    drop(fs::remove_dir_all("vendor"));
+    let vendor = Command::new("cargo")
+        .arg("vendor")
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    assert!(vendor.status.success());
+
+    fs::create_dir_all(".cargo").unwrap();
+    fs::write(".cargo/config.toml", vendor.stdout).unwrap();
+
+    for krate in crates {
+        if !krate.publish {
+            continue;
+        }
+        verify_and_vendor(&krate);
+    }
+
+    fn verify_and_vendor(krate: &Crate) {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("package")
+            .arg("--manifest-path")
+            .arg(&krate.manifest)
+            .env("CARGO_TARGET_DIR", "./target");
+        let status = cmd.status().unwrap();
+        assert!(status.success(), "failed to verify {:?}", &krate.manifest);
+        let tar = Command::new("tar")
+            .arg("xf")
+            .arg(format!(
+                "../target/package/{}-{}.crate",
+                krate.name, krate.version
+            ))
+            .current_dir("./vendor")
+            .status()
+            .unwrap();
+        assert!(tar.success());
+        fs::write(
+            format!(
+                "./vendor/{}-{}/.cargo-checksum.json",
+                krate.name, krate.version
+            ),
+            "{\"files\":{}}",
+        )
+        .unwrap();
+    }
+}

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -17,7 +17,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "cargo-component-macro",
     "cargo-component-bindings",
     "cargo-component-core",
-    //"wit",
+    "wit",
     "cargo-component",
 ];
 
@@ -29,7 +29,7 @@ const PUBLIC_CRATES: &[&str] = &[
     "cargo-component-macro",
     "cargo-component-bindings",
     "cargo-component-core",
-    //"wit",
+    "wit",
     "cargo-component",
 ];
 

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -10,7 +10,7 @@ keywords = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-cargo-component-core = { path = "../core" }
+cargo-component-core = { workspace = true }
 anyhow = { workspace = true }
 semver = { workspace = true }
 url = { workspace = true }

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 categories = { workspace = true }
 keywords = { workspace = true }
 repository = { workspace = true }
+readme = "README.md"
 
 [dependencies]
 cargo-component-core = { workspace = true }

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wit"
+# This tool has an independent version from `cargo-component`.
+version = "0.1.0"
 description = "A tool for building and publishing WIT packages to a registry."
-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/wit/README.md
+++ b/crates/wit/README.md
@@ -211,14 +211,10 @@ command. This is checked on CI.
 The CI for the `wit` repository is relatively significant. It tests
 changes on Windows, macOS, and Linux.
 
-It also performs a "dry run" of the release process to ensure that release
-binaries can be built and are ready to be published (_coming soon_).
-
-### Publishing (_coming soon_)
+### Publishing
 
 Publication of this crate is entirely automated via CI. A publish happens
 whenever a tag is pushed to the repository, so to publish a new version you'll
-want to make a PR that bumps the version numbers (see the `bump.rs` scripts in
-the root of the repository), merge the PR, then tag the PR and push the tag.
-That should trigger all that's necessary to publish all the crates and binaries
-to crates.io.
+want to make a PR that bumps the version numbers (see the `ci/publish.rs` 
+script), merge the PR, then tag the PR and push the tag. That should trigger 
+all that's necessary to publish all the crates and binaries to crates.io.

--- a/crates/wit/README.md
+++ b/crates/wit/README.md
@@ -13,8 +13,10 @@ for defining interfaces, types, and worlds used in WebAssembly components.
 
 ## Installation
 
+To install `wit` subcommand, run the following command:
+
 ```
-cargo install --git https://github.com/bytecodealliance/cargo-component --locked wit
+cargo install wit
 ```
 
 ## Initializing a WIT package

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -14,11 +14,10 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use toml_edit::{table, value, Document, InlineTable, Item, Table, Value};
+use toml_edit::{table, value, Document, Item, Table, Value};
 use url::Url;
 
 const BINDINGS_CRATE_NAME: &str = "cargo-component-bindings";
-const BINDINGS_CRATE_URL: &str = "https://github.com/bytecodealliance/cargo-component";
 
 fn escape_wit(s: &str) -> Cow<str> {
     match s {
@@ -289,8 +288,7 @@ impl NewCommand {
         metadata["component"] = Item::Table(component);
 
         doc["package"]["metadata"] = Item::Table(metadata);
-        doc["dependencies"][BINDINGS_CRATE_NAME] =
-            value(InlineTable::from_iter([("git", BINDINGS_CRATE_URL)]));
+        doc["dependencies"][BINDINGS_CRATE_NAME] = value(env!("CARGO_PKG_VERSION"));
 
         fs::write(&manifest_path, doc.to_string()).with_context(|| {
             format!(


### PR DESCRIPTION
This PR adds a GitHub action (based on a similar one from Wasmtime) for publishing the crates when new tags are created.

This also bumps the crate versions to 0.2.0, which will be the first versions of the crates published.