### PR TITLE
Fix bindings generation for exports of versioned interfaces.

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -285,10 +285,6 @@ impl Config {
                     key.push_str(&package.name.name);
                     key.push('/');
                     key.push_str(interface.name.as_ref().expect("interface must have a name"));
-                    if let Some(version) = package.name.version.as_ref() {
-                        key.push('@');
-                        key.push_str(&version.to_string());
-                    }
                     key
                 }
             };

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -285,6 +285,8 @@ impl Config {
                     key.push_str(&package.name.name);
                     key.push('/');
                     key.push_str(interface.name.as_ref().expect("interface must have a name"));
+                    // wit-bindgen expects to not have the package version number in
+                    // the export map, so don't append it here
                     key
                 }
             };


### PR DESCRIPTION
This PR fixes bindings generation for the exports of interfaces coming from versioned packages (i.e. the WIT package directive has a version on it).

The issue is that the export map passed through to wit-bindgen is expecting _not_ to have the version on the interface name as the version is associated with the package and not the interface.

The fix is to stop appending the version number when populating the exports map.