### PR TITLE
Refactor bindings generation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "wasm-metadata",
  "wasmparser 0.115.0",
  "wat",
+ "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-component",
  "wit-parser",
@@ -550,13 +551,9 @@ dependencies = [
 name = "cargo-component-macro"
 version = "0.3.1"
 dependencies = [
- "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.38",
- "wit-bindgen-core",
- "wit-bindgen-rust",
- "wit-component",
 ]
 
 [[package]]
@@ -3843,7 +3840,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d92ce0ca6b6074059413a9581a637550c3a740581c854f9847ec293c8aed71"
 dependencies = [
  "bitflags 2.4.1",
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -3867,21 +3863,6 @@ dependencies = [
  "heck",
  "wasm-metadata",
  "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91835ea4231da1fe7971679d505ba14be7826e192b6357f08465866ef482e08"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.38",
- "wit-bindgen-core",
- "wit-bindgen-rust",
  "wit-component",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 indexmap = { workspace = true }
 url = { workspace = true }
 wit-bindgen-rust = { workspace = true }
+wit-bindgen-core = { workspace = true }
 wit-parser = { workspace = true }
 wit-component = { workspace = true }
 wasm-metadata = { workspace = true }
@@ -97,4 +98,3 @@ quote = "1.0.33"
 syn = "2.0.38"
 wit-bindgen-rust = "0.13.0"
 wit-bindgen-core = "0.13.0"
-wit-bindgen = "0.13.0"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -11,4 +11,4 @@ repository = { workspace = true }
 
 [dependencies]
 cargo-component-macro = { workspace = true }
-wit-bindgen = { workspace = true }
+wit-bindgen = { version = "0.13.0", default-features = false, features = ["realloc"]}

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -16,7 +16,3 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-wit-bindgen-core = { workspace = true }
-wit-bindgen-rust = { workspace = true }
-wit-component = { workspace = true }
-heck = { workspace = true }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -2,42 +2,51 @@
 
 #![deny(missing_docs)]
 
-use heck::ToUpperCamelCase;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
-use std::{
-    borrow::Cow,
-    collections::HashMap,
-    fmt::Write,
-    fs,
-    path::{Path, PathBuf},
-};
-use syn::{
-    parse::{Parse, ParseStream},
-    parse_quote,
-    punctuated::Punctuated,
-    token, Error, Result, Token,
-};
-use wit_bindgen_core::{
-    wit_parser::{Resolve, TypeDefKind, WorldId, WorldItem, WorldKey},
-    Files,
-};
-use wit_bindgen_rust::{ExportKey, Opts, Ownership};
-use wit_component::DecodedWasm;
+use quote::quote;
+use std::path::{Path, PathBuf};
+use syn::{Error, Result};
 
-fn implementor_path_str(path: &syn::Path) -> String {
-    let mut s = String::new();
-    s.push_str("super::");
+fn bindings_source_path() -> Result<PathBuf> {
+    let path = Path::new(env!("CARGO_TARGET_DIR"))
+        .join("bindings")
+        .join(
+            std::env::var("CARGO_PKG_NAME")
+                .expect("failed to get `CARGO_PKG_NAME` environment variable"),
+        )
+        .join("bindings.rs");
 
-    for (i, segment) in path.segments.iter().enumerate() {
-        if i > 0 {
-            s.push_str("::");
-        }
-
-        write!(&mut s, "{ident}", ident = segment.ident).unwrap();
+    if !path.is_file() {
+        return Err(Error::new(
+            Span::call_site(),
+            format!(
+                "bindings file `{path}` does not exist\n\n\
+                 did you forget to run `cargo component build`? (https://github.com/bytecodealliance/cargo-component)",
+                path = path.display()
+            ),
+        ));
     }
 
-    s
+    Ok(path)
+}
+
+fn generate_bindings(input: proc_macro::TokenStream) -> Result<TokenStream> {
+    if !input.is_empty() {
+        return Err(Error::new(
+            Span::call_site(),
+            "the `generate!` macro does not take any arguments",
+        ));
+    }
+
+    let path = bindings_source_path()?;
+    let path = path.to_str().expect("bindings path is not valid UTF-8");
+
+    Ok(quote! {
+        /// Generated bindings module for this component.
+        pub(crate) mod bindings {
+            include!(#path);
+        }
+    })
 }
 
 /// Used to generate bindings for a WebAssembly component.
@@ -53,389 +62,43 @@ fn implementor_path_str(path: &syn::Path) -> String {
 /// on a type named `File` in the same scope as the `generate!`
 /// macro invocation.
 ///
-/// # Options
+/// # Settings
 ///
-/// The macro accepts the following options:
+/// Use the `package.metadata.component.bindings` section in
+/// `Cargo.toml` to configure bindings generation.
+///
+/// The available settings are:
 ///
 /// - `implementor`: The name of the type to implement world exports on.
 /// - `resources`: A map of resource names to resource implementor types.
 /// - `ownership`: The ownership model to use for resources.
-/// - `additional_derives`: Additional derive macro attributes to add to generated types
+/// - `derives`: Additional derive macro attributes to add to generated types.
 ///
 /// # Examples
 ///
-/// Using the default implementor names:
-///
-/// ```ignore
-/// cargo_component_bindings::generate!()
-/// ```
-///
 /// Specifying a custom implementor type named `MyComponent`:
 ///
-/// ```ignore
-/// cargo_component_bindings::generate!({
-///     implementor: MyComponent,
-/// })
+/// ```toml
+/// [package.metadata.component.bindings]
+/// implementor = "MyComponent"
 /// ```
 ///
 /// Specifying a custom resource implementor type named `MyResource`:
 ///
-/// ```ignore
-/// cargo_component_bindings::generate!({
-///     resources: {
-///         "my:package/iface/res": MyResource,
-///     }
-/// })
+/// ```toml
+/// [package.metadata.component.bindings.resources]
+/// "my:package/iface/res" = "MyResource"
 /// ```
 ///
-/// Specifying the `borrowing-duplicate-if-necessary` ownership model
-/// for resources:
+/// Specifying the `borrowing-duplicate-if-necessary` ownership model:
 ///
-/// ```ignore
-/// cargo_component_bindings::generate!({
-///      ownership: "borrowing-duplicate-if-necessary"
-/// })
+/// ```toml
+/// [package.metadata.component.bindings]
+/// ownership = "borrowing-duplicate-if-necessary"
+/// ````
 #[proc_macro]
 pub fn generate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    syn::parse_macro_input!(input as Config)
-        .expand()
+    generate_bindings(input)
         .unwrap_or_else(Error::into_compile_error)
         .into()
-}
-
-fn target_path() -> Result<PathBuf> {
-    Ok(Path::new(env!("CARGO_TARGET_DIR"))
-        .join("bindings")
-        .join(
-            std::env::var("CARGO_PKG_NAME")
-                .expect("failed to get `CARGO_PKG_NAME` environment variable"),
-        )
-        .join("target.wasm"))
-}
-
-fn decode_resolve(path: &Path, span: Span) -> Result<(Resolve, WorldId)> {
-    let bytes = std::fs::read(path).map_err(|e| {
-        Error::new(
-            span,
-            format!(
-                "failed to read target file `{path}`: {e}\n\n\
-                 did you forget to run `cargo component build`? (https://github.com/bytecodealliance/cargo-component)",
-                path = path.display()
-            ),
-        )
-    })?;
-
-    let decoded = wit_component::decode(&bytes).map_err(|e| {
-        Error::new(
-            span,
-            format!(
-                "failed to decode target file `{path}`: {e}",
-                path = path.display()
-            ),
-        )
-    })?;
-
-    let world_path = path.with_file_name("world");
-    let world = fs::read_to_string(&world_path).map_err(|e| {
-        Error::new(
-            span,
-            format!(
-                "failed to read world file `{path}`: {e}",
-                path = world_path.display()
-            ),
-        )
-    })?;
-
-    match decoded {
-        DecodedWasm::WitPackage(resolve, pkg) => {
-            let world = resolve
-                .select_world(pkg, if world.is_empty() { None } else { Some(&world) })
-                .map_err(|e| Error::new(span, format!("failed to select world for target: {e}")))?;
-            Ok((resolve, world))
-        }
-        DecodedWasm::Component(_, _) => Err(Error::new(
-            span,
-            format!(
-                "target file `{path}` is not a WIT package",
-                path = path.display()
-            ),
-        )),
-    }
-}
-
-mod kw {
-    syn::custom_keyword!(implementor);
-    syn::custom_keyword!(resources);
-    syn::custom_keyword!(ownership);
-    syn::custom_keyword!(additional_derives);
-}
-
-#[derive(Clone)]
-struct Resource {
-    key: syn::LitStr,
-    value: syn::Path,
-}
-
-impl Parse for Resource {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let key = input.parse()?;
-        input.parse::<Token![:]>()?;
-        let value = input.parse()?;
-        Ok(Self { key, value })
-    }
-}
-
-enum Opt {
-    Implementor(Span, syn::Path),
-    Resources(Span, Vec<Resource>),
-    Ownership(Span, Ownership),
-    // Parse as paths so we can take the concrete types/macro names rather than raw strings
-    AdditionalDerives(Vec<syn::Path>),
-}
-
-impl Parse for Opt {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let l = input.lookahead1();
-        if l.peek(kw::implementor) {
-            let span = input.parse::<kw::implementor>()?.span;
-            input.parse::<Token![:]>()?;
-            Ok(Opt::Implementor(span, input.parse()?))
-        } else if l.peek(kw::resources) {
-            let span = input.parse::<kw::resources>()?.span;
-            input.parse::<Token![:]>()?;
-            let contents;
-            syn::braced!(contents in input);
-            Ok(Opt::Resources(
-                span,
-                Punctuated::<_, Token![,]>::parse_terminated(&contents)?
-                    .iter()
-                    .cloned()
-                    .collect(),
-            ))
-        } else if l.peek(kw::ownership) {
-            let span = input.parse::<kw::ownership>()?.span;
-            input.parse::<Token![:]>()?;
-            let ownership = input.parse::<syn::LitStr>()?;
-            Ok(Opt::Ownership(
-                span,
-                ownership
-                    .value()
-                    .parse()
-                    .map_err(|e| Error::new(ownership.span(), e))?,
-            ))
-        } else if l.peek(kw::additional_derives) {
-            input.parse::<kw::additional_derives>()?;
-            input.parse::<Token![:]>()?;
-            let contents;
-            syn::bracketed!(contents in input);
-            let list = Punctuated::<_, Token![,]>::parse_terminated(&contents)?;
-            Ok(Opt::AdditionalDerives(list.into_iter().collect()))
-        } else {
-            Err(l.error())
-        }
-    }
-}
-
-struct Config {
-    input: PathBuf,
-    resolve: Resolve,
-    world: WorldId,
-    implementor: Option<syn::Path>,
-    resources: HashMap<String, syn::Path>,
-    ownership: Ownership,
-    additional_derives: Vec<String>,
-}
-
-impl Config {
-    fn expand(self) -> Result<TokenStream> {
-        fn resource_implementor(
-            key: &str,
-            name: &str,
-            resources: &HashMap<String, syn::Path>,
-        ) -> String {
-            implementor_path_str(&resources.get(key).map(Cow::Borrowed).unwrap_or_else(|| {
-                Cow::Owned(
-                    syn::PathSegment::from(syn::Ident::new(
-                        &name.to_upper_camel_case(),
-                        Span::call_site(),
-                    ))
-                    .into(),
-                )
-            }))
-        }
-
-        let implementor =
-            implementor_path_str(&self.implementor.unwrap_or_else(|| parse_quote!(Component)));
-
-        let world = &self.resolve.worlds[self.world];
-        let mut exports = HashMap::new();
-        exports.insert(ExportKey::World, implementor.clone());
-
-        for (name, item) in &world.exports {
-            let key = match name {
-                WorldKey::Name(name) => name.clone(),
-                WorldKey::Interface(id) => {
-                    let interface = &self.resolve.interfaces[*id];
-                    let package = &self.resolve.packages
-                        [interface.package.expect("interface must have a package")];
-
-                    let mut key = String::new();
-                    key.push_str(&package.name.namespace);
-                    key.push(':');
-                    key.push_str(&package.name.name);
-                    key.push('/');
-                    key.push_str(interface.name.as_ref().expect("interface must have a name"));
-                    // wit-bindgen expects to not have the package version number in
-                    // the export map, so don't append it here
-                    key
-                }
-            };
-
-            let implementor = match item {
-                WorldItem::Interface(id) => {
-                    let interface = &self.resolve.interfaces[*id];
-                    for (name, ty) in &interface.types {
-                        match self.resolve.types[*ty].kind {
-                            TypeDefKind::Resource => {
-                                let key = format!("{key}/{name}");
-                                let implementor = resource_implementor(&key, name, &self.resources);
-                                exports.insert(ExportKey::Name(key), implementor);
-                            }
-                            _ => continue,
-                        }
-                    }
-
-                    implementor.clone()
-                }
-                WorldItem::Type(id) => match self.resolve.types[*id].kind {
-                    TypeDefKind::Resource => resource_implementor(&key, &key, &self.resources),
-                    _ => continue,
-                },
-                WorldItem::Function(_) => implementor.clone(),
-            };
-
-            exports.insert(ExportKey::Name(key), implementor);
-        }
-
-        let opts = Opts {
-            exports,
-            ownership: self.ownership,
-            runtime_path: Some("::cargo_component_bindings::rt".to_string()),
-            bitflags_path: Some("::cargo_component_bindings::bitflags".to_string()),
-            additional_derive_attributes: self.additional_derives,
-            ..Default::default()
-        };
-
-        let mut files = Files::default();
-        opts.build()
-            .generate(&self.resolve, self.world, &mut files)
-            .map_err(|e| {
-                Error::new(
-                    Span::call_site(),
-                    format!(
-                        "failed to generate bindings from `{path}`: {e}",
-                        path = self.input.display()
-                    ),
-                )
-            })?;
-
-        let sources: Vec<_> = files
-            .iter()
-            .map(|(_, s)| std::str::from_utf8(s).unwrap())
-            .collect();
-        assert!(
-            sources.len() == 1,
-            "expected exactly one source file to be generated"
-        );
-
-        let source = sources[0].parse::<TokenStream>()?;
-        let input = self.input.display().to_string();
-
-        Ok(quote! {
-            pub(crate) mod bindings {
-                #source
-
-                const _: &[u8] = include_bytes!(#input);
-            }
-        })
-    }
-}
-
-impl Parse for Config {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let mut implementor: Option<syn::Path> = None;
-        let mut resources: Option<Vec<Resource>> = None;
-        let mut ownership: Option<Ownership> = None;
-        let mut additional_derives = Vec::new();
-
-        if input.peek(token::Brace) {
-            let content;
-            syn::braced!(content in input);
-            let options = Punctuated::<Opt, Token![,]>::parse_terminated(&content)?;
-            for option in options.into_pairs() {
-                match option.into_value() {
-                    Opt::Implementor(span, value) => {
-                        if implementor.is_some() {
-                            return Err(Error::new(
-                                span,
-                                "cannot specify `implementor` more than once",
-                            ));
-                        }
-
-                        if let Some(segment) = value.segments.first() {
-                            if segment.ident == "self" || segment.ident == "crate" {
-                                return Err(Error::new(
-                                    segment.ident.span(),
-                                    "cannot use `self` or `crate` as the implementor path",
-                                ));
-                            }
-                        }
-
-                        implementor = Some(value);
-                    }
-                    Opt::Resources(span, value) => {
-                        if resources.is_some() {
-                            return Err(Error::new(
-                                span,
-                                "cannot specify `resources` more than once",
-                            ));
-                        }
-
-                        resources = Some(value);
-                    }
-                    Opt::Ownership(span, value) => {
-                        if ownership.is_some() {
-                            return Err(Error::new(
-                                span,
-                                "cannot specify `ownership` more than once",
-                            ));
-                        }
-
-                        ownership = Some(value);
-                    }
-                    Opt::AdditionalDerives(paths) => {
-                        additional_derives = paths
-                            .into_iter()
-                            .map(|p| p.into_token_stream().to_string())
-                            .collect()
-                    }
-                }
-            }
-        }
-
-        let input = target_path()?;
-        let (resolve, world) = decode_resolve(&input, Span::call_site())?;
-
-        Ok(Config {
-            input,
-            resolve,
-            world,
-            implementor,
-            resources: resources
-                .map(|r| r.into_iter().map(|r| (r.key.value(), r.value)).collect())
-                .unwrap_or_default(),
-            ownership: ownership.unwrap_or_default(),
-            additional_derives,
-        })
-    }
 }

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use cargo_component::{
     commands::{AddCommand, KeyCommand, NewCommand, PublishCommand, UpdateCommand},
     config::{CargoArguments, Config},
@@ -165,7 +165,13 @@ async fn main() -> Result<()> {
                 cargo_args.packages.iter(),
                 cargo_args.workspace,
             )?;
-            assert!(!packages.is_empty());
+
+            if packages.is_empty() {
+                bail!(
+                    "manifest `{path}` contains no package or the workspace has no members",
+                    path = metadata.workspace_root.join("Cargo.toml")
+                );
+            }
 
             let spawn_args: Vec<_> = std::env::args().skip(1).collect();
             if let Err(e) = run_cargo_command(

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -159,7 +159,7 @@ async fn main() -> Result<()> {
                 cargo_args.color.unwrap_or_default(),
             ))?;
 
-            let metadata = load_metadata(cargo_args.manifest_path.as_deref())?;
+            let metadata = load_metadata(config.terminal(), cargo_args.manifest_path.as_deref())?;
             let packages = load_component_metadata(
                 &metadata,
                 cargo_args.packages.iter(),

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2,18 +2,22 @@
 
 use crate::{
     last_modified_time,
-    metadata::{ComponentMetadata, Target},
+    metadata::{ComponentMetadata, Ownership, Target},
     registry::PackageDependencyResolution,
 };
 use anyhow::{bail, Context, Result};
 use cargo_component_core::registry::DecodedDependency;
+use heck::ToUpperCamelCase;
 use indexmap::{IndexMap, IndexSet};
 use std::{
-    collections::HashSet,
+    borrow::Cow,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::SystemTime,
 };
 use warg_protocol::registry::PackageId;
+use wit_bindgen_core::Files;
+use wit_bindgen_rust::{ExportKey, Opts};
 use wit_component::DecodedWasm;
 use wit_parser::{
     Interface, Package, PackageName, Resolve, Type, TypeDefKind, TypeOwner, UnresolvedPackage,
@@ -32,20 +36,20 @@ fn named_world_key<'a>(resolve: &'a Resolve, orig: &'a WorldKey, prefix: &str) -
     WorldKey::Name(format!("{prefix}-{name}"))
 }
 
-/// An encoder for bindings information.
+/// A generator for bindings.
 ///
-/// This type is responsible for encoding the target world
-/// into a binary wasm file that the `generate!` macro
-/// will use for generating the bindings.
-pub struct BindingsEncoder<'a> {
+/// This type is responsible for generating the bindings
+/// that the `generate!` macro will ultimately include
+/// in user component projects.
+pub struct BindingsGenerator<'a> {
     resolution: &'a PackageDependencyResolution<'a>,
     resolve: Resolve,
     world: WorldId,
     source_files: Vec<PathBuf>,
 }
 
-impl<'a> BindingsEncoder<'a> {
-    /// Creates a new bindings encoder for the given bindings directory
+impl<'a> BindingsGenerator<'a> {
+    /// Creates a new bindings generator for the given bindings directory
     /// and package dependency resolution.
     pub fn new(resolution: &'a PackageDependencyResolution<'a>) -> Result<Self> {
         let (resolve, world, source_files) =
@@ -74,8 +78,13 @@ impl<'a> BindingsEncoder<'a> {
     ///
     /// If this returns `Ok(None)`, then the bindings are up-to-date and
     /// do not need to be regenerated.
-    pub fn reason(&self, last_modified_output: SystemTime) -> Result<Option<&'static str>> {
+    pub fn reason(
+        &self,
+        last_modified_exe: SystemTime,
+        last_modified_output: SystemTime,
+    ) -> Result<Option<&'static str>> {
         let metadata = self.metadata();
+        let exe_modified = last_modified_exe > last_modified_output;
         let manifest_modified = metadata.modified_at > last_modified_output;
         let target_modified = if let Some(path) = metadata.target_path() {
             last_modified_time(&path)? > last_modified_output
@@ -83,7 +92,8 @@ impl<'a> BindingsEncoder<'a> {
             false
         };
 
-        if manifest_modified
+        if exe_modified
+            || manifest_modified
             || target_modified
             || self.dependencies_are_newer(last_modified_output)?
         {
@@ -91,6 +101,8 @@ impl<'a> BindingsEncoder<'a> {
                 "the manifest was modified"
             } else if target_modified {
                 "the target WIT file was modified"
+            } else if exe_modified {
+                "the cargo-component executable was modified"
             } else {
                 "a dependency was modified"
             }))
@@ -99,33 +111,115 @@ impl<'a> BindingsEncoder<'a> {
         }
     }
 
-    /// Encodes the target world to a binary format.
-    pub fn encode(mut self) -> Result<Vec<u8>> {
-        let world = &self.resolve.worlds[self.world];
-        let pkg_id = world.package.context("world has no package")?;
-        let pkg = &mut self.resolve.packages[pkg_id];
+    /// Generates the bindings source for a package.
+    pub fn generate(self) -> Result<String> {
+        let settings = &self.resolution.metadata.section.bindings;
 
-        self.resolve
-            .package_names
-            .remove(&pkg.name)
-            .with_context(|| format!("package name `{name}` is not in map", name = pkg.name))?;
-
-        if self
-            .resolve
-            .package_names
-            .insert(pkg.name.clone(), pkg_id)
-            .is_some()
-        {
-            bail!("duplicate package name `{name}`", name = pkg.name);
+        fn implementor_path_str(path: &str) -> String {
+            format!("super::{path}")
         }
 
-        wit_component::encode(
-            Some(true),
-            &self.resolve,
-            self.resolve.worlds[self.world]
-                .package
-                .context("world has no package")?,
-        )
+        fn resource_implementor(
+            key: &str,
+            name: &str,
+            resources: &HashMap<String, String>,
+        ) -> String {
+            implementor_path_str(
+                &resources
+                    .get(key)
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| Cow::Owned(name.to_upper_camel_case())),
+            )
+        }
+
+        let implementor =
+            implementor_path_str(settings.implementor.as_deref().unwrap_or("Component"));
+
+        let world = &self.resolve.worlds[self.world];
+        let mut exports = HashMap::new();
+        exports.insert(ExportKey::World, implementor.clone());
+
+        for (name, item) in &world.exports {
+            let key = match name {
+                WorldKey::Name(name) => name.clone(),
+                WorldKey::Interface(id) => {
+                    let interface = &self.resolve.interfaces[*id];
+                    let package = &self.resolve.packages
+                        [interface.package.expect("interface must have a package")];
+
+                    let mut key = String::new();
+                    key.push_str(&package.name.namespace);
+                    key.push(':');
+                    key.push_str(&package.name.name);
+                    key.push('/');
+                    key.push_str(interface.name.as_ref().expect("interface must have a name"));
+                    // wit-bindgen expects to not have the package version number in
+                    // the export map, so don't append it here
+                    key
+                }
+            };
+
+            let implementor = match item {
+                WorldItem::Interface(id) => {
+                    let interface = &self.resolve.interfaces[*id];
+                    for (name, ty) in &interface.types {
+                        match self.resolve.types[*ty].kind {
+                            TypeDefKind::Resource => {
+                                let key = format!("{key}/{name}");
+                                let implementor =
+                                    resource_implementor(&key, name, &settings.resources);
+                                exports.insert(ExportKey::Name(key), implementor);
+                            }
+                            _ => continue,
+                        }
+                    }
+
+                    implementor.clone()
+                }
+                WorldItem::Type(id) => match self.resolve.types[*id].kind {
+                    TypeDefKind::Resource => resource_implementor(&key, &key, &settings.resources),
+                    _ => continue,
+                },
+                WorldItem::Function(_) => implementor.clone(),
+            };
+
+            exports.insert(ExportKey::Name(key), implementor);
+        }
+
+        let opts = Opts {
+            exports,
+            ownership: match settings.ownership {
+                Ownership::Owning => wit_bindgen_rust::Ownership::Owning,
+                Ownership::Borrowing => wit_bindgen_rust::Ownership::Borrowing {
+                    duplicate_if_necessary: false,
+                },
+                Ownership::BorrowingDuplicateIfNecessary => {
+                    wit_bindgen_rust::Ownership::Borrowing {
+                        duplicate_if_necessary: true,
+                    }
+                }
+            },
+            runtime_path: Some("::cargo_component_bindings::rt".to_string()),
+            bitflags_path: Some("::cargo_component_bindings::bitflags".to_string()),
+            additional_derive_attributes: settings.derives.clone(),
+            ..Default::default()
+        };
+
+        let mut files = Files::default();
+        opts.build()
+            .generate(&self.resolve, self.world, &mut files)
+            .context("failed to generate bindings")?;
+
+        let sources: Vec<_> = files
+            .iter()
+            .map(|(_, s)| std::str::from_utf8(s).expect("expected utf-8 bindings source"))
+            .collect();
+        assert!(
+            sources.len() == 1,
+            "expected exactly one source file to be generated"
+        );
+
+        Ok(sources[0].to_string())
     }
 
     fn dependencies_are_newer(&self, last_modified_output: SystemTime) -> Result<bool> {
@@ -180,6 +274,10 @@ impl<'a> BindingsEncoder<'a> {
             // For now, set it to the name from the id
             let world = &mut resolve.worlds[component_world_id];
             world.name = id.name().to_string();
+
+            let pkg = &mut resolve.packages[world.package.unwrap()];
+            pkg.name.namespace = id.namespace().to_string();
+            pkg.name.name = id.name().to_string();
 
             let source = merged
                 .merge(resolve)
@@ -399,14 +497,17 @@ impl<'a> BindingsEncoder<'a> {
     // This is used for dependencies on other components so that their exports may
     // be imported by the component being built.
     fn import_world(resolve: &mut Resolve, source: WorldId, target: WorldId) -> Result<()> {
-        let mut types = IndexMap::default();
         let mut functions = IndexMap::default();
         let mut interfaces = IndexMap::new();
         let name;
+        let docs;
+        let source_pkg;
 
         {
             let source = &resolve.worlds[source];
             name = source.name.clone();
+            docs = source.docs.clone();
+            source_pkg = source.package;
 
             // Check for imported types, which must also import any owning interfaces
             for item in source.imports.values() {
@@ -428,17 +529,14 @@ impl<'a> BindingsEncoder<'a> {
                     WorldItem::Interface(i) => {
                         interfaces.insert(named_world_key(resolve, key, &name), *i);
                     }
-                    WorldItem::Type(t) => {
-                        types.insert(key.clone().unwrap_name(), *t);
-                    }
+                    _ => continue,
                 }
             }
         }
 
-        let target = &mut resolve.worlds[target];
         for (key, id) in interfaces {
             let named = matches!(key, WorldKey::Name(_));
-            if target
+            if resolve.worlds[target]
                 .imports
                 .insert(key, WorldItem::Interface(id))
                 .is_some()
@@ -453,16 +551,27 @@ impl<'a> BindingsEncoder<'a> {
             }
         }
 
-        if !types.is_empty() || !functions.is_empty() {
+        // If the world had functions, insert an interface that contains them.
+        if !functions.is_empty() {
             let interface = resolve.interfaces.alloc(Interface {
                 name: Some(name.clone()),
-                docs: Default::default(),
-                types,
+                docs,
+                types: Default::default(),
                 functions,
-                package: target.package,
+                package: source_pkg,
             });
 
-            if target
+            // Add any types owned by the world to the interface
+            for (id, ty) in resolve.types.iter() {
+                if ty.owner == TypeOwner::World(source) {
+                    resolve.interfaces[interface]
+                        .types
+                        .insert(ty.name.clone().expect("type should have a name"), id);
+                }
+            }
+
+            // Finally, insert the interface into the target world
+            if resolve.worlds[target]
                 .imports
                 .insert(
                     WorldKey::Name(name.clone()),

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -65,7 +65,7 @@ impl AddCommand {
     /// Executes the command
     pub async fn exec(self) -> Result<()> {
         let config = Config::new(self.common.new_terminal())?;
-        let metadata = load_metadata(self.manifest_path.as_deref())?;
+        let metadata = load_metadata(config.terminal(), self.manifest_path.as_deref())?;
 
         let PackageComponentMetadata { package, metadata }: PackageComponentMetadata<'_> =
             match &self.spec {

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -1,4 +1,7 @@
-use crate::{config::Config, generator::SourceGenerator, metadata, metadata::DEFAULT_WIT_DIR};
+use crate::{
+    config::Config, generator::SourceGenerator, metadata, metadata::DEFAULT_WIT_DIR,
+    BINDINGS_CRATE_NAME,
+};
 use anyhow::{bail, Context, Result};
 use cargo_component_core::{
     command::CommonOptions,
@@ -16,8 +19,6 @@ use std::{
 };
 use toml_edit::{table, value, Document, Item, Table, Value};
 use url::Url;
-
-const BINDINGS_CRATE_NAME: &str = "cargo-component-bindings";
 
 fn escape_wit(s: &str) -> Cow<str> {
     match s {

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -92,7 +92,7 @@ impl PublishCommand {
             }
         }
 
-        let metadata = load_metadata(self.manifest_path.as_deref())?;
+        let metadata = load_metadata(config.terminal(), self.manifest_path.as_deref())?;
         let packages = [PackageComponentMetadata::new(
             if let Some(spec) = &self.cargo_package {
                 metadata

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -38,7 +38,7 @@ impl UpdateCommand {
     pub async fn exec(self) -> Result<()> {
         log::debug!("executing update command");
         let config = Config::new(self.common.new_terminal())?;
-        let metadata = load_metadata(self.manifest_path.as_deref())?;
+        let metadata = load_metadata(config.terminal(), self.manifest_path.as_deref())?;
         let packages = load_component_metadata(&metadata, [].iter(), true)?;
 
         let network_allowed = !self.frozen && !self.offline;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Context, Result};
 use assert_cmd::prelude::OutputAssertExt;
+use cargo_component::BINDINGS_CRATE_NAME;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -33,7 +34,7 @@ pub fn test_signing_key() -> &'static str {
 pub fn redirect_bindings_crate(doc: &mut Document) {
     const PATH_TO_BINDINGS_CRATE: &str = "../../../../../crates/bindings";
 
-    doc["dependencies"]["cargo-component-bindings"] =
+    doc["dependencies"][BINDINGS_CRATE_NAME] =
         value(InlineTable::from_iter([("path", PATH_TO_BINDINGS_CRATE)]));
 }
 


### PR DESCRIPTION
This PR alters how bindings generation works in `cargo-component`.

Previously, `cargo-component` would encode a target world for the `generate!` macro to decode. The macro would decode the target and feed it to `wit-bindgen` and expand to the generated bindings.

This approach had a few drawbacks:

* compilation times for projects increased as `wit-bindgen` had to be built from the component itself.
* rust-analyzer would not re-expand the `generate!` macro on WIT file changes as it does not add a source dependency via `include_bytes!`.
* "go to definition" doesn't work with rust-analyzer as the bindings code was entirely from the macro expansion.

To fix all three issues, `cargo-component` now generates the bindings source file itself and the macro simply expands to `include!` it.

This cuts the initial crate dependencies for a project from 50 to 13, speeding up the build (and our CI).

And as the `include_bytes!` is now an `include!`, rust-analyzer adds a source file dependency to re-expand the macro when any local WIT files change (on next reparse, that is).

However, this comes at the cost of being a breaking change:

* if the `cargo-component-bindings` crate version referenced from the project is mismatched from `cargo-component` following this change, the component project will not build as they won't agree on how to generate bindings.
* any users that provide arguments to the previous `generate!` macro must move those arguments into the `[package.metadata.component.bindings]` section in `Cargo.toml`.

Fixes #139.