### PR TITLE
Bump cargo-component version to 0.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-bindings"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cargo-component-macro",
  "wit-bindgen",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-macro"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "wit"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 readme = "README.md"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
@@ -61,8 +61,8 @@ members = ["crates/bindings", "crates/macro", "crates/core", "crates/wit"]
 exclude = ["target/tests"]
 
 [workspace.dependencies]
-cargo-component-core = { path = "crates/core", version = "0.3.1" }
-cargo-component-macro = { path = "crates/macro", version = "0.3.1" }
+cargo-component-core = { path = "crates/core", version = "0.4.0" }
+cargo-component-macro = { path = "crates/macro", version = "0.4.0" }
 warg-protocol = "0.2.0"
 warg-crypto = "0.2.0"
 warg-client = "0.2.0"

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit"
 # This tool has an independent version from `cargo-component`.
-version = "0.2.1"
+version = "0.3.0"
 description = "A tool for building and publishing WIT packages to a registry."
 edition = { workspace = true }
 authors = { workspace = true }


### PR DESCRIPTION
This also bumps `wit` to 0.3.0.