### PR TITLE
Remove linux aarch64 published artifact for now.

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -30,8 +30,6 @@ jobs:
         include:
           - rust-target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - rust-target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
           - rust-target: x86_64-apple-darwin
             os: macos-latest
           - rust-target: aarch64-apple-darwin
@@ -47,9 +45,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.rust-target }}
-      - name: Install libssl-dev:arm64
-        run: sudo apt-get --assume-yes install libssl-dev:arm64
-        if: matrix.rust-target == 'aarch64-unknown-linux-gnu'
       - run: cargo build --release --target ${{ matrix.rust-target }}
         env:
           CARGO_PROFILE_RELEASE_PANIC: abort
@@ -74,8 +69,6 @@ jobs:
         include:
           - rust-target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - rust-target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
           - rust-target: x86_64-apple-darwin
             os: macos-latest
           - rust-target: aarch64-apple-darwin
@@ -88,9 +81,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.rust-target }}
-      - name: Install libssl-dev:arm64
-        run: sudo apt-get --assume-yes install libssl-dev:arm64
-        if: matrix.rust-target == 'aarch64-unknown-linux-gnu'
       - run: cargo build --release --target ${{ matrix.rust-target }}
         env:
           CARGO_PROFILE_RELEASE_PANIC: abort


### PR DESCRIPTION
Until someone needs a linux aarch64 prebuilt artifact and wants to get a proper cross-compilation for it (or upstream changes to warg to remove the dep on openssl), this PR removes it from the publish matrix.