### PR TITLE
Better error message when deserializing `RegistryPackage`

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -213,7 +213,9 @@ impl FromStr for RegistryPackage {
     fn from_str(s: &str) -> Result<Self> {
         Ok(Self {
             id: None,
-            version: s.parse()?,
+            version: s
+                .parse()
+                .with_context(|| format!("'{s}' is an invalid registry package version"))?,
             registry: None,
         })
     }


### PR DESCRIPTION
Currently, when a component dependency is specified as a string it is assumed to be the version of the dependency on the registry. If, however, the user thinks that this could be path to a local wit definition, the error message is very confusing.

This changes adds a bit more context so hopefully the issue is clearer.