### PR TITLE
Suppress dead code warnings in bindings.

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -43,6 +43,7 @@ fn generate_bindings(input: proc_macro::TokenStream) -> Result<TokenStream> {
 
     Ok(quote! {
         /// Generated bindings module for this component.
+        #[allow(dead_code)]
         pub(crate) mod bindings {
             include!(#path);
         }


### PR DESCRIPTION
This PR suppresses dead code warnings caused by unused imports in the generated bindings.