### PR TITLE
Ensure CI runs on release branches.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, 'release-*']
     tags: ['[0-9]*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
 
 jobs:
   test:


### PR DESCRIPTION
This PR is cherry-picked from the `release-0.4.0` branch to ensure that CI runs for PRs and merges on release branches.