### PR TITLE
Fix bindings version warning and upgrade command.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use config::{CargoArguments, CargoPackageSpec, Config};
 use lock::{acquire_lock_file_ro, acquire_lock_file_rw};
 use metadata::ComponentMetadata;
 use registry::{PackageDependencyResolution, PackageResolutionMap};
-use semver::Version;
+use semver::{Version, VersionReq};
 use std::{
     borrow::Cow,
     fs::{self, File},
@@ -220,27 +220,28 @@ pub fn load_metadata(
 
     let metadata = command.exec().context("failed to load cargo metadata")?;
 
-    for package in &metadata.packages {
-        for dep in &package.dependencies {
-            if dep.rename.as_deref().unwrap_or(dep.name.as_str()) != BINDINGS_CRATE_NAME {
-                continue;
-            }
+    if !ignore_version_mismatch {
+        for package in &metadata.packages {
+            for dep in &package.dependencies {
+                if dep.rename.as_deref().unwrap_or(dep.name.as_str()) != BINDINGS_CRATE_NAME {
+                    continue;
+                }
 
-            if ignore_version_mismatch
-                || dep
-                    .req
-                    .matches(&Version::parse(env!("CARGO_PKG_VERSION")).unwrap())
-            {
-                continue;
-            }
+                let req = VersionReq::parse(env!("CARGO_PKG_VERSION")).unwrap();
+                let v = dep.req.to_string();
+                match v.strip_prefix('^').unwrap_or(&v).parse::<Version>() {
+                    Ok(v) if req.matches(&v) => break,
+                    _ => {}
+                }
 
-            terminal.warn(
-                format!(
-                    "mismatched version of `{BINDINGS_CRATE_NAME}` detected in manifest `{path}`: please update the version in the manifest to {version}",
-                    path = package.manifest_path,
-                    version = env!("CARGO_PKG_VERSION")
-                )
-            )?;
+                terminal.warn(
+                    format!(
+                        "mismatched version of `{BINDINGS_CRATE_NAME}` detected in manifest `{path}` (expected a version compatible with {version}); use `cargo component upgrade --no-install` to update",
+                        path = package.manifest_path,
+                        version = env!("CARGO_PKG_VERSION")
+                    )
+                )?;
+            }
         }
     }
 

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -777,7 +777,7 @@ fn it_errors_if_adapter_is_not_wasm() -> Result<()> {
 }
 
 #[test]
-fn it_warns_on_mismatched_bindings_crate_version() -> Result<()> {
+fn it_warns_on_outdated_bindings_crate_version() -> Result<()> {
     let project = Project::new("foo")?;
     project.update_manifest(|mut doc| {
         doc["dependencies"][BINDINGS_CRATE_NAME] = value("0.2.0");
@@ -787,9 +787,28 @@ fn it_warns_on_mismatched_bindings_crate_version() -> Result<()> {
     project
         .cargo_component("build")
         .assert()
-        .stderr(contains(
-            "warning: mismatched version of `cargo-component-bindings` detected in manifest",
-        ))
+        .stderr(contains(format!(
+            "uses an older version of `{BINDINGS_CRATE_NAME}` (0.2.0) than cargo-component"
+        )))
+        .failure();
+
+    Ok(())
+}
+
+#[test]
+fn it_warns_on_outdated_cargo_component_version() -> Result<()> {
+    let project = Project::new("foo")?;
+    project.update_manifest(|mut doc| {
+        doc["dependencies"][BINDINGS_CRATE_NAME] = value("1000.0.0");
+        Ok(doc)
+    })?;
+
+    project
+        .cargo_component("build")
+        .assert()
+        .stderr(contains(format!(
+            "uses a newer version of `{BINDINGS_CRATE_NAME}` (1000.0.0) than cargo-component"
+        )))
         .failure();
 
     Ok(())

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -25,11 +25,11 @@ fn upgrade_single_crate_already_current_is_no_op() -> Result<()> {
     let project = Project::with_root(&root, "component", "")?;
 
     project
-        .cargo_component("upgrade")
+        .cargo_component("upgrade --no-install")
         .assert()
         .success()
         .stderr(contains(
-            "Skipping package `component` as it already uses the current bindings crate version",
+            "Skipping package `component` as it already uses a compatible bindings crate version",
         ));
 
     Ok(())
@@ -60,12 +60,12 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
     );
 
     project
-        .cargo_component("upgrade")
+        .cargo_component("upgrade --no-install")
         .assert()
         .success()
         .stderr(contains("Updated "))
         .stderr(contains(format!(
-            "from ^0.1 to {}",
+            "from 0.1 to {}",
             env!("CARGO_PKG_VERSION")
         )));
 
@@ -82,11 +82,11 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
 
     // A repeated upgrade should recognize that there is no change required.
     project
-        .cargo_component("upgrade")
+        .cargo_component("upgrade --no-install")
         .assert()
         .success()
         .stderr(contains(
-            "Skipping package `component` as it already uses the current bindings crate version",
+            "Skipping package `component` as it already uses a compatible bindings crate version",
         ));
 
     Ok(())
@@ -117,13 +117,13 @@ fn upgrade_dry_run_does_not_alter_manifest() -> Result<()> {
     );
 
     project
-        .cargo_component("upgrade --dry-run")
+        .cargo_component("upgrade --no-install --dry-run")
         .assert()
         .success()
         .stderr(contains("Would update "))
         .stderr(contains("Updated ").not())
         .stderr(contains(format!(
-            "from ^0.1 to {}",
+            "from 0.1 to {}",
             env!("CARGO_PKG_VERSION")
         )));
 

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -41,7 +41,7 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
     let project = Project::with_root(&root, "component", "")?;
     project.update_manifest(|mut doc| {
         // Set arbitrary old version of bindings crate.
-        doc["dependencies"][BINDINGS_CRATE_NAME] = value("0.1");
+        doc["dependencies"][BINDINGS_CRATE_NAME] = value("0.1.0");
         Ok(doc)
     })?;
 
@@ -52,7 +52,7 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
     let manifest = project.read_manifest()?;
     assert_eq!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
-        Some("0.1")
+        Some("0.1.0")
     );
     assert_ne!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
@@ -65,7 +65,7 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
         .success()
         .stderr(contains("Updated "))
         .stderr(contains(format!(
-            "from 0.1 to {}",
+            "from 0.1.0 to {}",
             env!("CARGO_PKG_VERSION")
         )));
 
@@ -73,7 +73,7 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
     let manifest = project.read_manifest()?;
     assert_ne!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
-        Some("0.1")
+        Some("0.1.0")
     );
     assert_eq!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
@@ -93,12 +93,41 @@ fn upgrade_single_crate_upgrades_bindings_dep() -> Result<()> {
 }
 
 #[test]
+fn skip_packages_newer_than_cargo_component() -> Result<()> {
+    let root = create_root()?;
+    let project = Project::with_root(&root, "component", "")?;
+    project.update_manifest(|mut doc| {
+        // Set arbitrary future version of cargo-component
+        doc["dependencies"][BINDINGS_CRATE_NAME] = value("1000.0.0");
+        Ok(doc)
+    })?;
+
+    project
+        .cargo_component("upgrade --no-install")
+        .assert()
+        .success()
+        .stderr(contains("Skipping "))
+        .stderr(contains(
+            "using bindings crate version 1000.0.0 which is newer than cargo-component",
+        ));
+
+    // It should have not updated the manifest
+    let manifest = project.read_manifest()?;
+    assert_eq!(
+        manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
+        Some("1000.0.0")
+    );
+
+    Ok(())
+}
+
+#[test]
 fn upgrade_dry_run_does_not_alter_manifest() -> Result<()> {
     let root = create_root()?;
     let project = Project::with_root(&root, "component", "")?;
     project.update_manifest(|mut doc| {
         // Set arbitrary old version of bindings crate.
-        doc["dependencies"][BINDINGS_CRATE_NAME] = value("0.1");
+        doc["dependencies"][BINDINGS_CRATE_NAME] = value("0.1.0");
         Ok(doc)
     })?;
 
@@ -109,7 +138,7 @@ fn upgrade_dry_run_does_not_alter_manifest() -> Result<()> {
     let manifest = project.read_manifest()?;
     assert_eq!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
-        Some("0.1")
+        Some("0.1.0")
     );
     assert_ne!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
@@ -123,7 +152,7 @@ fn upgrade_dry_run_does_not_alter_manifest() -> Result<()> {
         .stderr(contains("Would update "))
         .stderr(contains("Updated ").not())
         .stderr(contains(format!(
-            "from 0.1 to {}",
+            "from 0.1.0 to {}",
             env!("CARGO_PKG_VERSION")
         )));
 
@@ -131,7 +160,7 @@ fn upgrade_dry_run_does_not_alter_manifest() -> Result<()> {
     let manifest = project.read_manifest()?;
     assert_eq!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),
-        Some("0.1")
+        Some("0.1.0")
     );
     assert_ne!(
         manifest["dependencies"][BINDINGS_CRATE_NAME].as_str(),


### PR DESCRIPTION
This PR fixes the warning emitted when a mismatched bindings version crate is detected such that it no longer warns when the bindings crate version is compatible, but not the same version (i.e. `0.4.1` when cargo-component is `0.4.0`).

Likewise, the `upgrade` command no longer attempts to downgrade the version of the bindings crate when it would otherwise be compatible.

The upgrade tests no longer attempt the install, which require a long time to just verify that a `cargo install cargo-component` would succeed, which isn't terribly useful.

The warning and upgrade command now both detect when cargo-component is outdated and instruct the user appropriately.