### PR TITLE
Use default component metadata when not present

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -81,13 +81,6 @@ impl AddCommand {
                 )?,
             };
 
-        let metadata = metadata.with_context(|| {
-            format!(
-                "manifest `{path}` is not a WebAssembly component package",
-                path = package.manifest_path
-            )
-        })?;
-
         let id = match &self.id {
             Some(id) => id,
             None => &self.package.id,

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -116,13 +116,7 @@ impl PublishCommand {
         )?];
 
         let package = packages[0].package;
-        let component_metadata = packages[0].metadata.as_ref().with_context(|| {
-            format!(
-                "package `{name}` is missing component metadata in manifest `{path}`",
-                name = package.name,
-                path = package.manifest_path
-            )
-        })?;
+        let component_metadata = &packages[0].metadata;
 
         let id = component_metadata.section.package.as_ref().with_context(|| {
             format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,7 @@ pub struct PackageComponentMetadata<'a> {
     /// The associated package.
     pub package: &'a Package,
     /// The associated component metadata.
-    ///
-    /// This is `None` if the package is not a component.
-    pub metadata: Option<ComponentMetadata>,
+    pub metadata: ComponentMetadata,
 }
 
 impl<'a> PackageComponentMetadata<'a> {
@@ -149,11 +147,6 @@ pub async fn run_cargo_command(
                 });
 
             for PackageComponentMetadata { package, metadata } in packages {
-                let metadata = match metadata {
-                    Some(metadata) => metadata,
-                    None => continue,
-                };
-
                 let is_bin = package.targets.iter().any(|t| t.is_bin());
 
                 // First try for <name>.wasm
@@ -362,15 +355,9 @@ async fn create_resolution_map<'a>(
     let mut map = PackageResolutionMap::default();
 
     for PackageComponentMetadata { package, metadata } in packages {
-        match metadata {
-            Some(metadata) => {
-                let resolution =
-                    PackageDependencyResolution::new(config, metadata, lock_file, network_allowed)
-                        .await?;
-                map.insert(package.id.clone(), resolution);
-            }
-            None => continue,
-        }
+        let resolution =
+            PackageDependencyResolution::new(config, metadata, lock_file, network_allowed).await?;
+        map.insert(package.id.clone(), resolution);
     }
 
     Ok(map)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -300,8 +300,8 @@ pub struct ComponentMetadata {
 impl ComponentMetadata {
     /// Creates a new component metadata for the given cargo package.
     ///
-    /// Returns `Ok(None)` if the package does not have a `component` section.
-    pub fn from_package(package: &Package) -> Result<Option<Self>> {
+    /// Uses `ComponentSection::default()` if the component metadata is not defined.
+    pub fn from_package(package: &Package) -> Result<Self> {
         log::debug!(
             "searching for component metadata in manifest `{path}`",
             path = package.manifest_path
@@ -361,13 +361,13 @@ impl ComponentMetadata {
             *adapter = manifest_dir.join(adapter.as_path());
         }
 
-        Ok(Some(Self {
+        Ok(Self {
             name: package.name.clone(),
             version: package.version.clone(),
             manifest_path: package.manifest_path.clone().into(),
             modified_at,
             section,
-        }))
+        })
     }
 
     /// Gets the path to a local target.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -307,7 +307,7 @@ impl ComponentMetadata {
             path = package.manifest_path
         );
 
-        let mut section: ComponentSection = match package.metadata.get("component").cloned() {
+        let mut section = match package.metadata.get("component").cloned() {
             Some(component) => from_value(component).with_context(|| {
                 format!(
                     "failed to deserialize component metadata from `{path}`",
@@ -319,7 +319,7 @@ impl ComponentMetadata {
                     "manifest `{path}` has no component metadata",
                     path = package.manifest_path
                 );
-                return Ok(None);
+                ComponentSection::default()
             }
         };
 


### PR DESCRIPTION
This PR makes the `[package.metadata.component]` section optional, using `ComponentSection::default()` if it's not present.

The thinking behind this, is that a user would never typically compile a regular wasm32-wasi module with `cargo component`. If they are using `cargo component build`, then they'd expect that the wasm module generated is a wasm component.

Closes https://github.com/bytecodealliance/cargo-component/issues/188