### PR TITLE
Check workspace with all targets in vscode, emacs configs

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -439,7 +439,14 @@ world example {{
                 fs::write(
                     &settings_path,
                     r#"{
-    "rust-analyzer.check.overrideCommand": ["cargo", "component", "check", "--message-format=json"]
+    "rust-analyzer.check.overrideCommand": [
+        "cargo",
+        "component",
+        "check",
+        "--workspace",
+        "--all-targets",
+        "--message-format=json"
+    ],
 }
 "#,
                 )
@@ -466,6 +473,8 @@ world example {{
               (lsp-rust-analyzer-cargo-override-command . ["cargo"
                                                            (\, "component")
                                                            (\, "check")
+                                                           (\, "--workspace")
+                                                           (\, "--all-targets")
                                                            (\, "--message-format=json")]))))
 "#,
                 )


### PR DESCRIPTION
Add `--workspace` and `--all-targets` switches to both vscode and emacs configs, that are generated in `cargo component new`. This is in line with what rust-analyzer uses when
`rust-analyzer.check.overrideCommand` is empty.
Fixes #203 .