### PR TITLE
Use current package with `add`, `publish` when in a workspace

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -10,7 +10,7 @@ use cargo_component_core::{
     registry::{Dependency, DependencyResolution, DependencyResolver, RegistryPackage},
     VersionedPackageId,
 };
-use cargo_metadata::{Metadata, Package};
+use cargo_metadata::Package;
 use clap::Args;
 use semver::VersionReq;
 use std::{
@@ -62,21 +62,6 @@ pub struct AddCommand {
 }
 
 impl AddCommand {
-    fn find_current_package_spec(metadata: &Metadata) -> Option<CargoPackageSpec> {
-        let current_manifest = fs::read_to_string("Cargo.toml").ok()?;
-        let document: Document = current_manifest.parse().ok()?; // TODO do not parse the manifest twice
-        let name = document["package"]["name"].as_str()?;
-        let version = metadata
-            .packages
-            .iter()
-            .find(|found| found.name == name)
-            .map(|found| found.version.clone());
-        Some(CargoPackageSpec {
-            name: name.to_string(),
-            version: version,
-        })
-    }
-
     /// Executes the command
     pub async fn exec(self) -> Result<()> {
         let config = Config::new(self.common.new_terminal())?;
@@ -84,7 +69,7 @@ impl AddCommand {
 
         let spec = match &self.spec {
             Some(spec) => Some(spec.clone()),
-            None => Self::find_current_package_spec(&metadata),
+            None => CargoPackageSpec::find_current_package_spec(&metadata),
         };
 
         let PackageComponentMetadata { package, metadata }: PackageComponentMetadata<'_> =

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -204,6 +204,7 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
     Ok((instance, config))
 }
 
+#[derive(Debug)]
 pub struct Project {
     pub dir: Rc<TempDir>,
     pub root: PathBuf,


### PR DESCRIPTION
Try to use current package in the `add` and `publish` command, when `-p` is not supplied and we are in a workspace.
Also isolate each test run. Previously all tests were sharing the same target/tests/Cargo.toml, which each test was modifying. This made order in which tests run significant and difficult to debug. Add test `two_projects_in_one_workspace_validate_add_from_path` which cretes two projects in the same workspace to make sure we modify the current package's manifest.