### PR TITLE
Spawn `cargo add` in the `new` command

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -51,13 +51,6 @@ fn it_builds_a_workspace() -> Result<()> {
     };
 
     project.file(
-        "Cargo.toml",
-        r#"[workspace]
-members = ["foo", "bar", "baz"]
-"#,
-    )?;
-
-    project.file(
         "baz/Cargo.toml",
         r#"[package]
 name = "baz"
@@ -81,6 +74,14 @@ edition = "2021"
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();
+
+    // Add the workspace after all of the projects have been created
+    project.file(
+        "Cargo.toml",
+        r#"[workspace]
+    members = ["foo", "bar", "baz"]
+    "#,
+    )?;
 
     project
         .cargo_component("build")

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -47,13 +47,6 @@ fn it_checks_a_workspace() -> Result<()> {
     };
 
     project.file(
-        "Cargo.toml",
-        r#"[workspace]
-members = ["foo", "bar", "baz"]
-"#,
-    )?;
-
-    project.file(
         "baz/Cargo.toml",
         r#"[package]
 name = "baz"
@@ -77,6 +70,14 @@ edition = "2021"
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();
+
+    // Add the workspace after all of the packages have been created.
+    project.file(
+        "Cargo.toml",
+        r#"[workspace]
+    members = ["foo", "bar", "baz"]
+    "#,
+    )?;
 
     project
         .cargo_component("check")

--- a/tests/clippy.rs
+++ b/tests/clippy.rs
@@ -68,13 +68,6 @@ fn it_checks_a_workspace() -> Result<()> {
     };
 
     project.file(
-        "Cargo.toml",
-        r#"[workspace]
-members = ["foo", "bar", "baz"]
-"#,
-    )?;
-
-    project.file(
         "baz/Cargo.toml",
         r#"[package]
 name = "baz"
@@ -98,6 +91,14 @@ edition = "2021"
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();
+
+    // Add the workspace after all of the packages have been created.
+    project.file(
+        "Cargo.toml",
+        r#"[workspace]
+members = ["foo", "bar", "baz"]
+"#,
+    )?;
 
     project
         .cargo_component("clippy")

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -45,13 +45,6 @@ fn it_prints_workspace_metadata() -> Result<()> {
     };
 
     project.file(
-        "Cargo.toml",
-        r#"[workspace]
-members = ["foo", "bar", "baz"]
-"#,
-    )?;
-
-    project.file(
         "baz/Cargo.toml",
         r#"[package]
 name = "baz"
@@ -75,6 +68,14 @@ edition = "2021"
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();
+
+    // Add the workspace after all of the packages have been created.
+    project.file(
+        "Cargo.toml",
+        r#"[workspace]
+members = ["foo", "bar", "baz"]
+"#,
+    )?;
 
     project
         .cargo_component("metadata --format-version 1")


### PR DESCRIPTION
Fixes #204
`cargo component add` now spawns `cargo add cargo-component-bindings` . This has a few implications:
* It makes the command a bit slower as it needs to fetch the metadata from the network
* It uses the latest version by default.
* When in a workspace, and `cargo-component-bindings` is already defined as a workspace dependency, it uses the workspace version.

`cargo component upgrade` was not changed. I believe this command does too much and should be reconsidered.

Tests did not have to be changed, but checking a specific `cargo-component-bindings` version in tests might be problematic.