### PR TITLE
Rename `--reactor` to `--lib` for `new` subcommand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,12 @@ support in `cargo component` for adapting a _preview1_ module will be removed.
 
 ## Getting Started
 
-Use `cargo component new --reactor <name>` to create a new reactor component.
+Use `cargo component new --lib <name>` to create a new library (reactor) 
+component.
 
-A reactor component doesn't have a `run` (i.e. `main` in Rust) function
+A library component doesn't have a `run` (i.e. `main` in Rust) function
 exported and is meant to be used as a library rather than a command that runs
-and exits. Without the `--reactor` flag, `cargo component` defaults to creating
+and exits. Without the `--lib` flag, `cargo component` defaults to creating
 a command component.
 
 This will create a `wit/world.wit` file describing the world that the

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -47,13 +47,13 @@ pub struct NewCommand {
     #[clap(long = "vcs", value_name = "VCS", value_parser = ["git", "hg", "pijul", "fossil", "none"])]
     pub vcs: Option<String>,
 
-    /// Create a command component [default]
-    #[clap(long = "command", conflicts_with("reactor"))]
+    /// Create a CLI command component [default]
+    #[clap(long = "command", conflicts_with("lib"))]
     pub command: bool,
 
-    /// Create a reactor component
-    #[clap(long = "reactor")]
-    pub reactor: bool,
+    /// Create a library (reactor) component
+    #[clap(long = "lib", alias = "reactor")]
+    pub lib: bool,
 
     /// Edition to set for the generated crate
     #[clap(long = "edition", value_name = "YEAR", value_parser = ["2015", "2018", "2021"])]
@@ -76,12 +76,7 @@ pub struct NewCommand {
     pub editor: Option<String>,
 
     /// Use the specified target world from a WIT package.
-    #[clap(
-        long = "target",
-        short = 't',
-        value_name = "TARGET",
-        requires = "reactor"
-    )]
+    #[clap(long = "target", short = 't', value_name = "TARGET", requires = "lib")]
     pub target: Option<String>,
 
     /// Use the specified default registry when generating the package.
@@ -307,7 +302,7 @@ impl NewCommand {
     }
 
     fn is_command(&self) -> bool {
-        self.command || !self.reactor
+        self.command || !self.lib
     }
 
     fn generate_source(

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -80,7 +80,7 @@ edition = "2021"
     project.file("baz/src/lib.rs", "")?;
 
     project
-        .cargo_component("new --reactor foo")
+        .cargo_component("new --lib foo")
         .assert()
         .stderr(contains("Updated manifest of package `foo`"))
         .success();
@@ -95,7 +95,7 @@ edition = "2021"
     })?;
 
     project
-        .cargo_component("new --reactor bar")
+        .cargo_component("new --lib bar")
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -75,7 +75,7 @@ edition = "2021"
     project.file("baz/src/lib.rs", "")?;
 
     project
-        .cargo_component("new --reactor foo")
+        .cargo_component("new --lib foo")
         .assert()
         .stderr(contains("Updated manifest of package `foo`"))
         .success();
@@ -90,7 +90,7 @@ edition = "2021"
     })?;
 
     project
-        .cargo_component("new --reactor bar")
+        .cargo_component("new --lib bar")
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();

--- a/tests/clippy.rs
+++ b/tests/clippy.rs
@@ -100,7 +100,7 @@ edition = "2021"
     project.file("baz/src/lib.rs", "")?;
 
     project
-        .cargo_component("new --reactor foo")
+        .cargo_component("new --lib foo")
         .assert()
         .stderr(contains("Updated manifest of package `foo`"))
         .success();
@@ -115,7 +115,7 @@ edition = "2021"
     })?;
 
     project
-        .cargo_component("new --reactor bar")
+        .cargo_component("new --lib bar")
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -69,7 +69,7 @@ edition = "2021"
     project.file("baz/src/lib.rs", "")?;
 
     project
-        .cargo_component("new --reactor foo")
+        .cargo_component("new --lib foo")
         .assert()
         .stderr(contains("Updated manifest of package `foo`"))
         .success();
@@ -84,7 +84,7 @@ edition = "2021"
     })?;
 
     project
-        .cargo_component("new --reactor bar")
+        .cargo_component("new --lib bar")
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
         .success();

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -44,7 +44,7 @@ fn it_creates_the_expected_files_for_bin() -> Result<()> {
 fn it_creates_the_expected_files() -> Result<()> {
     let dir = TempDir::new()?;
 
-    cargo_component("new --reactor foo")
+    cargo_component("new --lib foo")
         .current_dir(dir.path())
         .assert()
         .stderr(contains("Updated manifest of package `foo`"))
@@ -65,7 +65,7 @@ fn it_creates_the_expected_files() -> Result<()> {
 fn it_supports_editor_option() -> Result<()> {
     let dir = TempDir::new()?;
 
-    cargo_component("new --reactor foo --editor none")
+    cargo_component("new --lib foo --editor none")
         .current_dir(dir.path())
         .assert()
         .stderr(contains("Updated manifest of package `foo"))
@@ -85,7 +85,7 @@ fn it_supports_editor_option() -> Result<()> {
 fn it_supports_edition_option() -> Result<()> {
     let dir = TempDir::new()?;
 
-    cargo_component("new --reactor foo --edition 2018")
+    cargo_component("new --lib foo --edition 2018")
         .current_dir(dir.path())
         .assert()
         .stderr(contains("Updated manifest of package `foo"))
@@ -102,7 +102,7 @@ fn it_supports_edition_option() -> Result<()> {
 fn it_supports_name_option() -> Result<()> {
     let dir = TempDir::new()?;
 
-    cargo_component("new --reactor foo --name bar")
+    cargo_component("new --lib foo --name bar")
         .current_dir(dir.path())
         .assert()
         .stderr(contains("Updated manifest of package `bar`"))
@@ -119,7 +119,7 @@ fn it_supports_name_option() -> Result<()> {
 fn it_rejects_rust_keywords() -> Result<()> {
     let dir = TempDir::new()?;
 
-    cargo_component("new --reactor foo --name fn")
+    cargo_component("new --lib foo --name fn")
         .current_dir(dir.path())
         .assert()
         .stderr(contains(
@@ -179,6 +179,18 @@ async fn it_errors_if_target_does_not_exist() -> Result<()> {
         Ok(_) => panic!("expected error"),
         Err(e) => assert!(contains("package `foo:bar` does not exist").eval(&e.to_string())),
     }
+
+    Ok(())
+}
+
+#[test]
+fn it_supports_the_reactor_option() -> Result<()> {
+    let dir = TempDir::new()?;
+
+    cargo_component("new --reactor foo")
+        .current_dir(dir.path())
+        .assert()
+        .try_success()?;
 
     Ok(())
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -214,7 +214,7 @@ impl Project {
     pub fn new(name: &str) -> Result<Self> {
         let dir = TempDir::new()?;
 
-        cargo_component(&format!("new --reactor {name}"))
+        cargo_component(&format!("new --lib {name}"))
             .current_dir(dir.path())
             .assert()
             .try_success()?;
@@ -244,7 +244,7 @@ impl Project {
     }
 
     pub fn with_dir(dir: Rc<TempDir>, name: &str, args: &str) -> Result<Self> {
-        cargo_component(&format!("new --reactor {name} {args}"))
+        cargo_component(&format!("new --lib {name} {args}"))
             .current_dir(dir.path())
             .assert()
             .try_success()?;


### PR DESCRIPTION
This PR renames the `--reactor` option for the `new` subcommand to `--lib`.

It maintains an alias of `--reactor` for backwards compatibility.

Updated the tests to use `--lib` and added a test to ensure `--reactor` is still respected.

Closes #198.