### PR TITLE
tests fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,14 +179,7 @@ pub async fn run_cargo_command(
             .unwrap_or_else(|| {
                 (
                     PathAndArgs::new("wasmtime")
-                        .args(vec![
-                            "-W",
-                            "component-model",
-                            "-S",
-                            "preview2",
-                            "-S",
-                            "common",
-                        ])
+                        .args(vec!["-S", "preview2", "-S", "common"])
                         .to_owned(),
                     true,
                 )

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -15,7 +15,7 @@ fn it_prints_metadata() -> Result<()> {
     project
         .cargo_component("metadata --format-version 1")
         .assert()
-        .stdout(contains("foo 0.1.0"))
+        .stdout(contains(r#""name":"foo","version":"0.1.0""#))
         .success();
 
     Ok(())
@@ -80,7 +80,12 @@ members = ["foo", "bar", "baz"]
     project
         .cargo_component("metadata --format-version 1")
         .assert()
-        .stdout(contains("foo 0.1.0").and(contains("bar 0.1.0").and(contains("baz 0.1.0"))))
+        .stdout(
+            contains(r#"name":"foo","version":"0.1.0""#).and(
+                contains(r#"name":"bar","version":"0.1.0""#)
+                    .and(contains(r#"name":"baz","version":"0.1.0""#)),
+            ),
+        )
         .success();
 
     Ok(())


### PR DESCRIPTION
Currently when building off of main, tests are failing out of the box.

Some tests were failing because they are using flags from before `wasmtime` enabled the component model by default, so those flags are no longer being used.

Others were matching against information output by running `cargo component metadata` and seemed to not expect json output, so there are changes for that too.