### PR TITLE
Anticipate packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
  "which 6.0.0",
  "wit-bindgen-core",
  "wit-bindgen-rust",
- "wit-component 0.20.0",
+ "wit-component",
  "wit-parser",
 ]
 
@@ -571,7 +571,7 @@ dependencies = [
  "warg-crypto",
  "warg-protocol",
  "windows-sys 0.52.0",
- "wit-component 0.20.0",
+ "wit-component",
  "wit-parser",
 ]
 
@@ -3654,15 +3654,6 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d162eb64168969ae90e8668ca0593b0e47667e315aa08e717a9c9574d700d826"
@@ -3682,7 +3673,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.40.0",
+ "wasm-encoder",
  "wasmparser 0.120.0",
 ]
 
@@ -3704,16 +3695,6 @@ name = "wasmparser"
 version = "0.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5"
-dependencies = [
- "indexmap 2.1.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.118.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
 dependencies = [
  "indexmap 2.1.0",
  "semver",
@@ -3749,7 +3730,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.40.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -4017,51 +3998,30 @@ dependencies = [
  "warg-server",
  "wasm-metadata",
  "wasmparser 0.120.0",
- "wit-component 0.20.0",
+ "wit-component",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d55e1a488af2981fb0edac80d8d20a51ac36897a1bdef4abde33c29c1b6d0d"
+source = "git+https://github.com/macovedj/wit-bindgen?branch=anticipate-packages#42569652bdb96b221b37cb51ae99f86e8e87bdbb"
 dependencies = [
  "anyhow",
- "wit-component 0.18.2",
+ "wit-component",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01ff9cae7bf5736750d94d91eb8a49f5e3a04aff1d1a3218287d9b2964510f8"
+source = "git+https://github.com/macovedj/wit-bindgen?branch=anticipate-packages#42569652bdb96b221b37cb51ae99f86e8e87bdbb"
 dependencies = [
  "anyhow",
  "heck",
  "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.18.2",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
-dependencies = [
- "anyhow",
- "bitflags 2.4.2",
- "indexmap 2.1.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.38.1",
- "wasm-metadata",
- "wasmparser 0.118.1",
- "wit-parser",
+ "wit-component",
 ]
 
 [[package]]
@@ -4077,7 +4037,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.40.0",
+ "wasm-encoder",
  "wasm-metadata",
  "wasmparser 0.120.0",
  "wit-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ rpassword = "7.3.1"
 futures = "0.3.30"
 bytes = "1.5.0"
 which = "6.0.0"
-wit-bindgen-rust = "0.16.0"
-wit-bindgen-core = "0.16.0"
+wit-bindgen-rust = { git = "https://github.com/macovedj/wit-bindgen", branch="anticipate-packages" }
+wit-bindgen-core = { git = "https://github.com/macovedj/wit-bindgen", branch="anticipate-packages" }
 tempfile = "3.9.0"
 assert_cmd = "2.0.13"
 predicates = "3.1.0"

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -33,7 +33,7 @@ fn named_world_key<'a>(resolve: &'a Resolve, orig: &'a WorldKey, prefix: &str) -
         }
     };
 
-    WorldKey::Name(format!("{prefix}-{name}"))
+    WorldKey::Name(format!("{prefix}/{name}"))
 }
 
 /// A generator for bindings.
@@ -505,6 +505,7 @@ impl<'a> BindingsGenerator<'a> {
             name = source.name.clone();
             docs = source.docs.clone();
             source_pkg = source.package;
+            let pkg = &resolve.packages[source_pkg.unwrap()];
 
             // Check for imported types, which must also import any owning interfaces
             for item in source.imports.values() {
@@ -524,7 +525,14 @@ impl<'a> BindingsGenerator<'a> {
                         functions.insert(key.clone().unwrap_name(), f.clone());
                     }
                     WorldItem::Interface(i) => {
-                        interfaces.insert(named_world_key(resolve, key, &name), *i);
+                        interfaces.insert(
+                            named_world_key(
+                                resolve,
+                                key,
+                                &format!("{}:{}", pkg.name.namespace, pkg.name.name),
+                            ),
+                            *i,
+                        );
                     }
                     _ => continue,
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,14 +179,7 @@ pub async fn run_cargo_command(
             .unwrap_or_else(|| {
                 (
                     PathAndArgs::new("wasmtime")
-                        .args(vec![
-                            "-W",
-                            "component-model",
-                            "-S",
-                            "preview2",
-                            "-S",
-                            "common",
-                        ])
+                        .args(vec!["-S", "preview2", "-S", "common"])
                         .to_owned(),
                     true,
                 )

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -15,7 +15,7 @@ fn it_prints_metadata() -> Result<()> {
     project
         .cargo_component("metadata --format-version 1")
         .assert()
-        .stdout(contains("foo 0.1.0"))
+        .stdout(contains(r#""name":"foo","version":"0.1.0""#))
         .success();
 
     Ok(())
@@ -80,7 +80,12 @@ members = ["foo", "bar", "baz"]
     project
         .cargo_component("metadata --format-version 1")
         .assert()
-        .stdout(contains("foo 0.1.0").and(contains("bar 0.1.0").and(contains("baz 0.1.0"))))
+        .stdout(
+            contains(r#"name":"foo","version":"0.1.0""#).and(
+                contains(r#"name":"bar","version":"0.1.0""#)
+                    .and(contains(r#"name":"baz","version":"0.1.0""#)),
+            ),
+        )
         .success();
 
     Ok(())


### PR DESCRIPTION
Today, one can publish a `cargo-component` generated component to a registry and then add it as a dependency in another  `cargo-component` project.  However, the consuming component's wit will not refer to a foreign package if an interface is imported, but instead will define that interface inline.  The example below should help make this clear.

Given a simple component with the following wit:

```
package component:hello;

interface greeter {
  hello-world: func() -> string;
}
/// An example world for the component to target.
world example {
  import greeter;
  export greeter;
}
```

That is added via `cargo-component add` to another component, we can reference it in the project that is added to like so:

```rs
use bindings::hello_greeter::hello_world;
use bindings::Guest;

struct Component;

impl Guest for Component {
    /// Say hello!
    fn goodbye_world() -> String {
        hello_world()
    }
}
```

However, when printing out the wit of the compiled component, the `greeter` interface appears as follows:

```
package root:component;

world root {
  import hello-greeter: interface {
    hello-world: func() -> string;
  }
  import wasi:cli/environment@0.2.0;
  import wasi:cli/exit@0.2.0;
  import wasi:io/error@0.2.0;
  import wasi:io/streams@0.2.0;
  import wasi:cli/stdin@0.2.0;
  import wasi:cli/stdout@0.2.0;
  import wasi:cli/stderr@0.2.0;
  import wasi:clocks/wall-clock@0.2.0;
  import wasi:filesystem/types@0.2.0;
  import wasi:filesystem/preopens@0.2.0;

  export goodbye-world: func() -> string;
}
```

We can see that it is not surfaced to the wit that this interface is defined by the dependency.  The use case I specifically am motivated by is in is docs gen so that a UI can link to the package where the type is actually defined.

These changes will produce a binary with the following wit

```
world root {
  import wasi:hello/greeter;
  import wasi:cli/environment@0.2.0;
  import wasi:cli/exit@0.2.0;
  import wasi:io/error@0.2.0;
  import wasi:io/streams@0.2.0;
  import wasi:cli/stdin@0.2.0;
  import wasi:cli/stdout@0.2.0;
  import wasi:cli/stderr@0.2.0;
  import wasi:clocks/wall-clock@0.2.0;
  import wasi:filesystem/types@0.2.0;
  import wasi:filesystem/preopens@0.2.0;

  export goodbye-world: func() -> string;
}
```

For the motivating use case, this would surface sufficient information for robust docgen.

Note that as it stands, in order for these changes to function properly would also require that the `wit-bindgen` branch referenced gets merged, which has the side effect of prepending the namespace to the module exposed in rust bindings, and the rust import would then look like so

```rs
use bindings::<namespace>_hello_greeter::hello_world;
```
