### PR TITLE
Add support for `std_feature`

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -199,6 +199,7 @@ impl<'a> BindingsGenerator<'a> {
                 }
             },
             additional_derive_attributes: settings.derives.clone(),
+            std_feature: settings.std_feature,
             ..Default::default()
         };
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -72,6 +72,9 @@ pub struct Bindings {
     pub ownership: Ownership,
     /// Additional derives to apply to generated binding types.
     pub derives: Vec<String>,
+    /// If true, code generation should qualify any features that depend on
+    /// `std` with `cfg(feature = "std")`.
+    pub std_feature: bool,
 }
 
 /// The target of a component.


### PR DESCRIPTION
Add support for the `std_feature` flag in
`[package.metadata.component.bindings]`, so that cargo-component can produce no_std components.