### PR TITLE
Bump `cargo-component` version to 0.9.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-component-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "wit"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 readme = "README.md"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
@@ -65,7 +65,7 @@ wasmprinter = { workspace = true }
 members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
-cargo-component-core = { path = "crates/core", version = "0.8.0" }
+cargo-component-core = { path = "crates/core", version = "0.9.0" }
 warg-protocol = "0.3.0"
 warg-crypto = "0.3.0"
 warg-client = "0.3.0"

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit"
 # This tool has an independent version from `cargo-component`.
-version = "0.7.0"
+version = "0.8.0"
 description = "A tool for building and publishing WIT packages to a registry."
 edition = { workspace = true }
 authors = { workspace = true }


### PR DESCRIPTION
This also bumps `wit` to 0.8.0.