### PR TITLE
Fix panic in bindings generation for component dependencies.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,8 +805,7 @@ async fn generate_package_bindings(
     let last_modified_output = bindings_path
         .is_file()
         .then(|| last_modified_time(&bindings_path))
-        .transpose()?
-        .unwrap_or(SystemTime::UNIX_EPOCH);
+        .transpose()?;
 
     let (generator, import_name_map) = BindingsGenerator::new(resolution)?;
     match generator.reason(last_modified_exe, last_modified_output)? {

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -519,9 +519,19 @@ interface types {
     }
 }
 
+interface types2 {
+    type seed = u32;
+}
+
+interface other {
+    use types2.{seed};
+    rand: func(seed: seed) -> u32;
+}
+
 world random-generator {
     use types.{seed};
     export rand: func(seed: seed) -> u32;
+    export other;
 }
 ",
     )?;
@@ -532,13 +542,19 @@ world random-generator {
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{Guest, Seed};
+use bindings::{Guest, Seed, exports::my::comp1::other};
 
 struct Component;
 
 impl Guest for Component {
     fn rand(seed: Seed) -> u32 {
         seed.value + 1
+    }
+}
+
+impl other::Guest for Component {
+    fn rand(seed: other::Seed) -> u32 {
+        seed + 2
     }
 }
 
@@ -579,13 +595,13 @@ world random-generator {
 #[allow(warnings)]
 mod bindings;
 
-use bindings::{Guest, my_comp1};
+use bindings::{Guest, my_comp1, my};
 
 struct Component;
 
 impl Guest for Component {
     fn rand() -> u32 {
-        my_comp1::rand(my_comp1::Seed { value: 1 })
+        my_comp1::rand(my_comp1::Seed { value: 1 }) + my::comp1::my_comp1_other::rand(1)
     }
 }
 


### PR DESCRIPTION
This PR fixes a panic originating in `wit-bindgen` that occurs when a component dependency exports an interface that contains a used type.

Previously, the bindings generation only added used interfaces for types directly used by the component's world (i.e. from exported functions).

The fix was to do the same for any exported interfaces as well.

Also added some more `log::debug!` for context around bindings generation.

Fixed an incorrect reason being logged for when the bindings source file doesn't exist.

Fixes #252.