### PR TITLE
Fix `new --target` option for exports with resources.

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -88,7 +88,17 @@ impl UseTrie {
     ///
     /// Any conflicting insert into the tree will use a qualified path instead.
     fn reserve_names(&mut self, names: &ReservedNames) {
-        self.types.extend(names.0.keys().cloned());
+        for (name, count) in &names.0 {
+            for i in 0..*count {
+                let name = if i > 0 {
+                    format!("{name}{i}", i = i + 1)
+                } else {
+                    name.clone()
+                };
+
+                self.types.insert(name);
+            }
+        }
     }
 
     /// Gets the used types at a given path.

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -162,6 +162,8 @@ interface bar {
 }
 
 interface baz {
+    use bar.{a as a2};
+
     resource a {
         constructor(a: borrow<a>);
         a: static func(a: borrow<a>) -> a;
@@ -174,6 +176,7 @@ interface baz {
         b: func(a: a);
     }
 
+    v: func(a2: borrow<a2>) -> a2;
     w: func(a: a) -> a;
     x: func(b: b) -> b;
     y: func(a: borrow<a>);

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -141,6 +141,45 @@ async fn it_targets_a_world() -> Result<()> {
         "test:bar",
         "1.2.3",
         r#"package test:bar@1.2.3;
+
+interface bar {
+    resource a {
+        constructor(a: borrow<a>);
+        a: static func(a: borrow<a>) -> a;
+        b: func(a: a);
+    }
+
+    resource b {
+        constructor(a: borrow<a>);
+        a: static func(a: borrow<a>) -> a;
+        b: func(a: a);
+    }
+
+    w: func(a: a) -> a;
+    x: func(b: b) -> b;
+    y: func(a: borrow<a>);
+    z: func(b: borrow<b>);
+}
+
+interface baz {
+    resource a {
+        constructor(a: borrow<a>);
+        a: static func(a: borrow<a>) -> a;
+        b: func(a: a);
+    }
+
+    resource b {
+        constructor(a: borrow<a>);
+        a: static func(a: borrow<a>) -> a;
+        b: func(a: a);
+    }
+
+    w: func(a: a) -> a;
+    x: func(b: b) -> b;
+    y: func(a: borrow<a>);
+    z: func(b: borrow<b>);
+}
+
 world foo {
     resource file {
         open: static func(path: string) -> file;
@@ -148,13 +187,14 @@ world foo {
     }
     import foo: func() -> file;
     export bar: func(file: borrow<file>) -> file;
+    export bar;
+    export baz;
 }"#,
         true,
     )
     .await?;
 
     let project = Project::with_dir(dir.clone(), "component", "--target test:bar@1.0.0")?;
-
     project
         .cargo_component("build")
         .assert()


### PR DESCRIPTION
This PR fixes the code generated by the `--target` option of the `new` subcommand when the exports contains a resource.

The code now conforms to the latest `wit-bindgen` output.