### PR TITLE
Prevent bindings generation for normal cargo projects.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,14 @@ async fn generate_package_bindings(
     last_modified_exe: SystemTime,
     cwd: &Path,
 ) -> Result<HashMap<String, String>> {
+    if !resolution.metadata.section_present && resolution.metadata.target_path().is_none() {
+        log::debug!(
+            "skipping generating bindings for package `{name}`",
+            name = resolution.metadata.name
+        );
+        return Ok(HashMap::new());
+    }
+
     // TODO: make the output path configurable
     let output_dir = resolution
         .metadata


### PR DESCRIPTION
This PR prevents bindings from being generated for "normal" cargo project.

Bindings will be generated if the project contains a `[package.metadata.component]` section in `Cargo.toml` or if it contains a `wit` subdirectory.

Fixes #258.