### PR TITLE
Implement `wit pull`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "warg-loader"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b65953b2a5c881de1208e05e12e1683902a3895d1e62891599da2401244edc"
+checksum = "39175875963059f6ac7330b8d449856e5bc6b26944565402f607bb4398d38359"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "warg-loader"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac86f76b2635e0a4e21c562aec94b8041bb8408c7047e16ed0fff34593ca019"
+checksum = "77b65953b2a5c881de1208e05e12e1683902a3895d1e62891599da2401244edc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,21 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -668,8 +680,10 @@ checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits 0.2.18",
  "serde 1.0.197",
+ "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 
@@ -943,6 +957,17 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "docker_credential"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
+dependencies = [
+ "base64 0.21.7",
+ "serde 1.0.197",
+ "serde_json",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1458,6 +1483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643c9bbf6a4ea8a656d6b4cd53d34f79e3f841ad5203c1a55fb7d761923bc255"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1591,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1573,12 +1608,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
@@ -1586,6 +1638,9 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.6",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1737,6 +1792,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde 1.0.197",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -2148,6 +2218,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-distribution"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a635cabf7a6eb4e5f13e9e82bd9503b7c2461bf277132e38638a935ebd684b4"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 0.2.11",
+ "http-auth",
+ "jwt",
+ "lazy_static 1.4.0",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.11.24",
+ "serde 1.0.197",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
+dependencies = [
+ "serde 1.0.197",
+ "serde_json",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2405,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "serde 1.0.197",
 ]
 
@@ -2753,7 +2859,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2762,7 +2868,7 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -2785,6 +2891,48 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e333b1eb9fe677f6893a9efcb0d277a2d3edd83f358a236b657c32301dc6e5f6"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.2",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde 1.0.197",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "winreg",
 ]
@@ -2865,7 +3013,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2924,6 +3072,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
+ "serde 1.0.197",
  "zeroize",
 ]
 
@@ -3085,7 +3234,7 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3841,7 +3990,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "ptree",
- "reqwest",
+ "reqwest 0.11.24",
  "secrecy",
  "semver",
  "serde 1.0.197",
@@ -3886,7 +4035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a8c47e96a7f1903931b34db9a1f0d22bcb3761a203ee6861db686daaedcb4b"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "digest",
  "hex",
  "leb128",
@@ -3898,6 +4047,36 @@ dependencies = [
  "sha2",
  "signature",
  "thiserror",
+]
+
+[[package]]
+name = "warg-loader"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac86f76b2635e0a4e21c562aec94b8041bb8408c7047e16ed0fff34593ca019"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "dirs",
+ "docker_credential",
+ "futures-util",
+ "oci-distribution",
+ "reqwest 0.12.1",
+ "secrecy",
+ "semver",
+ "serde 1.0.197",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "toml 0.8.10",
+ "tracing",
+ "tracing-subscriber",
+ "warg-client",
+ "warg-protocol",
 ]
 
 [[package]]
@@ -3926,7 +4105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69be98a2e9e0aeace7cbd62184b11462d259c5e391e6208d59506c9a2d33571c"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "hex",
  "indexmap 2.2.5",
  "pbjson-types",
@@ -4454,6 +4633,7 @@ dependencies = [
  "warg-client",
  "warg-credentials",
  "warg-crypto",
+ "warg-loader",
  "warg-protocol",
  "warg-server",
  "wasm-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ predicates = "3.1.0"
 wasmparser = "0.202.0"
 wat = "1.202.0"
 wasmprinter = "0.202.0"
-warg-loader = "0.0.4"
+warg-loader = "0.0.5"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ predicates = "3.1.0"
 wasmparser = "0.202.0"
 wat = "1.202.0"
 wasmprinter = "0.202.0"
-warg-loader = "0.0.5"
+warg-loader = "0.0.6"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ predicates = "3.1.0"
 wasmparser = "0.202.0"
 wat = "1.202.0"
 wasmprinter = "0.202.0"
+warg-loader = "0.0.4"
 
 [profile.release]
 panic = "abort"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod registry;
 pub mod terminal;
 
 /// Represents a versioned component package name.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VersionedPackageName {
     /// The package name.
     pub name: PackageName,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,3 +42,13 @@ impl FromStr for VersionedPackageName {
         }
     }
 }
+
+impl std::fmt::Display for VersionedPackageName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(version) = &self.version {
+            write!(f, "@{version}")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/wit/Cargo.toml
+++ b/crates/wit/Cargo.toml
@@ -35,6 +35,9 @@ futures = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true }
 pretty_env_logger = { workspace = true }
+warg-loader = { workspace = true }
+tempfile = { workspace = true }
+tokio-util = { workspace = true, features = ["io-util"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/wit/src/bin/wit.rs
+++ b/crates/wit/src/bin/wit.rs
@@ -3,7 +3,7 @@ use cargo_component_core::terminal::{Color, Terminal, Verbosity};
 use clap::Parser;
 use std::process::exit;
 use wit::commands::{
-    AddCommand, BuildCommand, InitCommand, KeyCommand, PublishCommand, UpdateCommand,
+    AddCommand, BuildCommand, InitCommand, KeyCommand, PublishCommand, PullCommand, UpdateCommand,
 };
 
 fn version() -> &'static str {
@@ -30,6 +30,7 @@ pub enum Command {
     Add(AddCommand),
     Build(BuildCommand),
     Publish(PublishCommand),
+    Pull(PullCommand),
     Key(KeyCommand),
     Update(UpdateCommand),
 }
@@ -45,6 +46,7 @@ async fn main() -> Result<()> {
         Command::Add(cmd) => cmd.exec().await,
         Command::Build(cmd) => cmd.exec().await,
         Command::Publish(cmd) => cmd.exec().await,
+        Command::Pull(cmd) => cmd.exec().await,
         Command::Key(cmd) => cmd.exec().await,
         Command::Update(cmd) => cmd.exec().await,
     } {

--- a/crates/wit/src/commands.rs
+++ b/crates/wit/src/commands.rs
@@ -5,6 +5,7 @@ mod build;
 mod init;
 mod key;
 mod publish;
+mod pull;
 mod update;
 
 pub use add::*;
@@ -12,4 +13,5 @@ pub use build::*;
 pub use init::*;
 pub use key::*;
 pub use publish::*;
+pub use pull::*;
 pub use update::*;

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -23,6 +23,8 @@ pub struct PullCommand {
     pub common: CommonOptions,
 
     /// Use the specified registry name as the default when pulling package(s).
+    /// Note: Currently 'wasi:' packages will be pulled from
+    /// 'bytecodealliance.org' regardless of this flag.
     #[clap(long, value_name = "REGISTRY")]
     pub registry: Option<String>,
 
@@ -111,8 +113,7 @@ impl PullCommand {
                     };
                     terminal.status("Downloaded", format!("release {release_pkg}"))?;
 
-                    let version = root_pkg.name.version.clone();
-                    if let Some(wit_version) = &version {
+                    if let Some(wit_version) = &root_pkg.name.version {
                         let release_version = &release.version;
                         if wit_version != release_version {
                             terminal.warn(format!("Release version {release_version} doesn't match WIT package version {wit_version}"))?;

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -205,7 +205,6 @@ impl PullCommand {
     }
 }
 
-#[derive(Debug)]
 struct PackagesState {
     // Packages currently present in the wit dir
     present: BTreeSet<PackageName>,
@@ -234,6 +233,11 @@ impl PackagesState {
         // Root package
         match UnresolvedPackage::parse_dir(wit_dir) {
             Ok(pkg) => {
+                log::debug!(
+                    "Parsed root package '{name}' deps = {deps:?}",
+                    name = pkg.name,
+                    deps = debug_pkg_names(pkg.foreign_deps.keys()),
+                );
                 present.insert(pkg.name);
                 deps.extend(pkg.foreign_deps.into_keys());
             }
@@ -258,6 +262,11 @@ impl PackagesState {
                 }
                 .with_context(|| format!("Error parsing {path:?}"))?;
 
+                log::debug!(
+                    "Parsed deps package '{name}' deps = {deps:?}",
+                    name = pkg.name,
+                    deps = debug_pkg_names(pkg.foreign_deps.keys()),
+                );
                 present.insert(pkg.name);
                 deps.extend(pkg.foreign_deps.into_keys());
             }
@@ -289,4 +298,20 @@ impl PackagesState {
         }
         false
     }
+}
+
+impl std::fmt::Debug for PackagesState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PackagesState")
+            .field("present", &debug_pkg_names(&self.present))
+            .field("deps", &debug_pkg_names(&self.deps))
+            .finish()
+    }
+}
+
+fn debug_pkg_names<'a>(names: impl IntoIterator<Item = &'a PackageName>) -> Vec<String> {
+    names
+        .into_iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
 }

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -1,0 +1,183 @@
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
+use clap::Args;
+
+use cargo_component_core::command::CommonOptions;
+use futures::TryStreamExt;
+use semver::Version;
+use tokio_util::io::{StreamReader, SyncIoBridge};
+use warg_loader::PackageRef;
+use wit_parser::UnresolvedPackage;
+
+/// Pull WIT package(s) to a local "deps" directory.
+#[derive(Args)]
+#[clap(disable_version_flag = true)]
+pub struct PullCommand {
+    /// The common command options.
+    #[clap(flatten)]
+    pub common: CommonOptions,
+
+    /// Use the specified registry name when pulling the package(s).
+    #[clap(long, value_name = "REGISTRY")]
+    pub registry: Option<String>,
+
+    /// Update the specified directory WIT "root" directory. Dependencies will
+    /// be written to e.g. "<wit-dir>/deps/<namespace>.<package>.wit".
+    #[clap(long, value_name = "WIT_DIR", default_value = "wit")]
+    pub wit_dir: PathBuf,
+
+    /// Create "<wit-dir>" and "<wit-dir>/deps" directories as needed.
+    #[clap(long)]
+    pub create_dirs: bool,
+
+    /// Pull the packages specified. If empty, the list of packages to pull will
+    /// be parsed from "<wit-dir>/deps/*.wit".
+    #[clap(value_name = "PACKAGE")]
+    pub packages: Vec<PackageRef>,
+}
+
+impl PullCommand {
+    /// Executes the command.
+    pub async fn exec(self) -> Result<()> {
+        log::debug!("executing pull command");
+
+        let terminal = self.common.new_terminal();
+
+        let deps_dir = self.wit_dir.join("deps");
+
+        let deps = if self.packages.is_empty() {
+            let deps = if deps_dir.exists() {
+                Dep::parse_deps_files(&deps_dir)
+                    .with_context(|| format!("Couldn't read existing deps from {deps_dir:?}"))?
+            } else {
+                vec![]
+            };
+            if deps.is_empty() {
+                terminal.warn(format!(
+                    "No deps found at {glob:?}; nothing to pull.",
+                    glob = deps_dir.join("*.wit")
+                ))?;
+                return Ok(());
+            }
+            deps
+        } else {
+            self.packages
+                .into_iter()
+                .map(|pkg| Dep::specific(pkg, &deps_dir))
+                .collect::<Result<Vec<_>>>()?
+        };
+
+        let mut client = match warg_loader::Client::from_default_config_file()? {
+            Some(client) => client,
+            None => warg_loader::Client::new(Default::default()),
+        };
+
+        if !deps_dir.exists() {
+            if self.create_dirs {
+                log::info!("Creating {deps_dir:?}");
+                std::fs::create_dir_all(&deps_dir)?;
+            } else {
+                bail!("Deps dir does not exist at {deps_dir:?}");
+            }
+        }
+
+        for dep in deps {
+            terminal.status("Pulling", format!("package {}", dep.pkg))?;
+            let pkg = &dep.pkg;
+            match dep.pull(&mut client).await {
+                Ok(Some(version)) => {
+                    terminal.status("Updated", format!("package {pkg} to version {version}"))?
+                }
+                Ok(None) => {
+                    terminal.status("Checked", format!("package {pkg}; no updates found"))?
+                }
+                Err(err) => terminal.error(format!("Couldn't pull package {pkg}: {err:?}"))?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct Dep {
+    path: PathBuf,
+    pkg: PackageRef,
+}
+
+impl Dep {
+    fn parse_file(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let pkg_name = UnresolvedPackage::parse_file(&path)?.name;
+        let pkg = format!("{}:{}", pkg_name.namespace, pkg_name.name).parse()?;
+        Ok(Self { path, pkg })
+    }
+
+    fn specific(pkg: PackageRef, deps_dir: &Path) -> Result<Self> {
+        let path = deps_dir.join(format!("{}_{}.wit", pkg.namespace(), pkg.name()));
+        if path.exists() {
+            Self::parse_file(path)
+        } else {
+            Ok(Self { path, pkg })
+        }
+    }
+
+    fn parse_deps_files(deps_dir: &Path) -> Result<Vec<Self>> {
+        let mut deps = vec![];
+        for entry in deps_dir
+            .read_dir()
+            .with_context(|| format!("couldn't read {deps_dir:?}"))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().unwrap_or_default() == "wit" && entry.file_type()?.is_file() {
+                match Self::parse_file(&path) {
+                    Ok(dep) => deps.push(dep),
+                    Err(err) => {
+                        log::warn!("Couldn't parse {path:?}: {err}");
+                        log::debug!("Full error: {err:?}");
+                    }
+                }
+            }
+        }
+        Ok(deps)
+    }
+
+    async fn pull(&self, client: &mut warg_loader::Client) -> Result<Option<Version>> {
+        let versions = client.list_all_versions(&self.pkg).await?;
+        let latest = versions.into_iter().max().context("no versions found")?;
+        let release = client.get_release(&self.pkg, &latest).await?;
+
+        let stream = client.stream_content(&self.pkg, &release).await?;
+        let stream = StreamReader::new(stream.map_err(|err| match err {
+            warg_loader::Error::IoError(err) => err,
+            other => std::io::Error::other(other),
+        }));
+        let reader = SyncIoBridge::new(stream);
+
+        let decoded = tokio::task::block_in_place(|| wit_component::decode_reader(reader))?;
+
+        let wit =
+            wit_component::WitPrinter::default().print(decoded.resolve(), decoded.package())?;
+
+        // TODO: instead, hash existing file and compare w/ release.content_digest above
+        let existing = std::fs::read(&self.path).unwrap_or_default();
+        if wit.as_bytes() == existing {
+            return Ok(None);
+        }
+
+        atomic_write(&self.path, wit.as_bytes())?;
+        Ok(Some(latest))
+    }
+}
+
+fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
+    let mut file =
+        tempfile::NamedTempFile::with_prefix_in(".tmp-wit-pull-", path.parent().unwrap())?;
+    file.write_all(contents)?;
+    file.persist(path)?;
+    Ok(())
+}

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -1,17 +1,18 @@
 use std::{
+    collections::{BTreeSet, HashSet},
     io::Write,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use anyhow::{bail, Context, Result};
 use clap::Args;
 
-use cargo_component_core::command::CommonOptions;
+use cargo_component_core::{command::CommonOptions, VersionedPackageName};
 use futures::TryStreamExt;
-use semver::Version;
 use tokio_util::io::{StreamReader, SyncIoBridge};
-use warg_loader::{ClientConfig, PackageRef};
-use wit_parser::UnresolvedPackage;
+use warg_loader::{ClientConfig, Release};
+use wit_component::DecodedWasm;
+use wit_parser::{PackageId, PackageName, Resolve, UnresolvedPackage};
 
 /// Pull WIT package(s) to a local "deps" directory.
 #[derive(Args)]
@@ -30,14 +31,14 @@ pub struct PullCommand {
     #[clap(long, value_name = "WIT_DIR", default_value = "wit")]
     pub wit_dir: PathBuf,
 
-    /// Create "<wit-dir>" and "<wit-dir>/deps" directories as needed.
+    /// Create "<wit-dir>" and "<wit-dir>/deps" directories if needed.
     #[clap(long)]
     pub create_dirs: bool,
 
-    /// Pull the packages specified. If empty, the list of packages to pull will
-    /// be parsed from "<wit-dir>/deps/*.wit".
+    /// Pull the packages specified. If empty, the list of packages to pull
+    /// will be inferred from missing dependencies.
     #[clap(value_name = "PACKAGE")]
-    pub packages: Vec<PackageRef>,
+    pub packages: Vec<VersionedPackageName>,
 }
 
 impl PullCommand {
@@ -47,29 +48,35 @@ impl PullCommand {
 
         let terminal = self.common.new_terminal();
 
-        let deps_dir = self.wit_dir.join("deps");
+        let (mut existing_pkgs, deps) = self.parse_packages_state()?;
+        log::debug!("Packages state: pkgs={existing_pkgs:?} deps={deps:?}");
 
-        let deps = if self.packages.is_empty() {
-            let deps = if deps_dir.exists() {
-                Dep::parse_deps_files(&deps_dir)
-                    .with_context(|| format!("Couldn't read existing deps from {deps_dir:?}"))?
-            } else {
-                vec![]
-            };
-            if deps.is_empty() {
-                terminal.warn(format!(
-                    "No deps found at {glob:?}; nothing to pull.",
-                    glob = deps_dir.join("*.wit")
-                ))?;
-                return Ok(());
-            }
-            deps
+        let packages = if self.packages.is_empty() {
+            // No packages specified; look for missing dependencies
+            deps.into_iter()
+                .filter(|pkg| !existing_pkgs.contains(pkg))
+                .map(|pkg| VersionedPackageName {
+                    name: wit_to_warg_package_name(&pkg),
+                    version: pkg.version.map(|ver| ver.to_string().parse().unwrap()),
+                })
+                .collect::<Vec<_>>()
         } else {
+            // Remove existing packages from given list
             self.packages
-                .into_iter()
-                .map(|pkg| Dep::specific(pkg, &deps_dir))
-                .collect::<Result<Vec<_>>>()?
+                .iter()
+                .filter(|pkg| {
+                    !existing_pkgs
+                        .iter()
+                        .any(|existing| version_satisfied(pkg, existing))
+                })
+                .cloned()
+                .collect()
         };
+
+        if packages.is_empty() {
+            terminal.status("Finished", "no missing packages; nothing to do")?;
+            return Ok(());
+        }
 
         let mut client = {
             let mut config = ClientConfig::default();
@@ -80,82 +87,119 @@ impl PullCommand {
             config.to_client()
         };
 
-        if !deps_dir.exists() {
-            if self.create_dirs {
-                log::info!("Creating {deps_dir:?}");
-                std::fs::create_dir_all(&deps_dir)?;
-            } else {
-                bail!("Deps dir does not exist at {deps_dir:?}");
+        let mut pulled = HashSet::new();
+        for pkg in packages {
+            let name = &pkg.name;
+            if !pulled.insert(name.clone()) {
+                continue;
             }
-        }
+            terminal.status("Resolving", format!("package {pkg}"))?;
 
-        for dep in deps {
-            terminal.status("Pulling", format!("package {}", dep.pkg))?;
-            let pkg = &dep.pkg;
-            match dep.pull(&mut client).await {
-                Ok(Some(version)) => {
-                    terminal.status("Updated", format!("package {pkg} to version {version}"))?
-                }
-                Ok(None) => {
-                    terminal.status("Checked", format!("package {pkg}; no updates found"))?
-                }
-                Err(err) => terminal.error(format!("Couldn't pull package {pkg}: {err:?}"))?,
-            }
-        }
+            match self.pull(&mut client, &pkg).await? {
+                Some((release, decoded)) => {
+                    let root_pkg = &decoded.resolve().packages[decoded.package()];
 
-        Ok(())
-    }
-}
+                    let release_pkg = PackageName {
+                        namespace: name.namespace().to_string(),
+                        name: name.name().to_string(),
+                        version: Some(release.version.clone()),
+                    };
+                    terminal.status("Downloaded", format!("release {release_pkg}"))?;
 
-struct Dep {
-    path: PathBuf,
-    pkg: PackageRef,
-}
+                    let version = root_pkg.name.version.clone();
+                    if let Some(wit_version) = &version {
+                        let release_version = &release.version;
+                        if wit_version != release_version {
+                            terminal.warn(format!("Release version {release_version} doesn't match WIT package version {wit_version}"))?;
+                        }
+                    }
 
-impl Dep {
-    fn parse_file(path: impl Into<PathBuf>) -> Result<Self> {
-        let path = path.into();
-        let pkg_name = UnresolvedPackage::parse_file(&path)?.name;
-        let pkg = format!("{}:{}", pkg_name.namespace, pkg_name.name).parse()?;
-        Ok(Self { path, pkg })
-    }
-
-    fn specific(pkg: PackageRef, deps_dir: &Path) -> Result<Self> {
-        let path = deps_dir.join(format!("{}_{}.wit", pkg.namespace(), pkg.name()));
-        if path.exists() {
-            Self::parse_file(path)
-        } else {
-            Ok(Self { path, pkg })
-        }
-    }
-
-    fn parse_deps_files(deps_dir: &Path) -> Result<Vec<Self>> {
-        let mut deps = vec![];
-        for entry in deps_dir
-            .read_dir()
-            .with_context(|| format!("couldn't read {deps_dir:?}"))?
-        {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().unwrap_or_default() == "wit" && entry.file_type()?.is_file() {
-                match Self::parse_file(&path) {
-                    Ok(dep) => deps.push(dep),
-                    Err(err) => {
-                        log::warn!("Couldn't parse {path:?}: {err}");
-                        log::debug!("Full error: {err:?}");
+                    for (package_id, package) in &decoded.resolve().packages {
+                        let name = &package.name;
+                        if !existing_pkgs.insert(name.clone()) {
+                            continue;
+                        }
+                        let path = self.write_package(decoded.resolve(), package_id)?;
+                        terminal.status(
+                            "Wrote",
+                            format!("package {name} to '{path}'", path = path.display()),
+                        )?;
                     }
                 }
+                None => {
+                    terminal.warn(format!("No package found for {pkg}"))?;
+                }
             }
         }
-        Ok(deps)
+        Ok(())
     }
 
-    async fn pull(&self, client: &mut warg_loader::Client) -> Result<Option<Version>> {
-        let versions = client.list_all_versions(&self.pkg).await?;
-        let latest = versions.into_iter().max().context("no versions found")?;
-        let release = client.get_release(&self.pkg, &latest).await?;
+    fn parse_packages_state(&self) -> Result<(BTreeSet<PackageName>, BTreeSet<PackageName>)> {
+        let mut resolve = Resolve::new();
 
-        let stream = client.stream_content(&self.pkg, &release).await?;
+        // If Resolve::push_dir succeeds there are no unresolved deps
+        match resolve.push_dir(&self.wit_dir) {
+            Ok(_) => {
+                return Ok((
+                    resolve.package_names.into_keys().collect(),
+                    Default::default(),
+                ))
+            }
+            Err(err) => log::debug!("Couldn't resolve packages: {err:#}"),
+        }
+
+        // Approximate the Resolve::push_dir process
+        // TODO: Try to expose this logic from wit-parser instead
+        let mut pkgs = match UnresolvedPackage::parse_dir(&self.wit_dir) {
+            Ok(pkg) => BTreeSet::from([pkg.name]),
+            Err(err) => {
+                log::debug!("Couldn't parse root package: {err:?}");
+                Default::default()
+            }
+        };
+        let mut deps = BTreeSet::new();
+        let deps_dir = self.wit_dir.join("deps");
+        if deps_dir.is_dir() {
+            for entry in deps_dir.read_dir()? {
+                let path = entry?.path();
+                if path.extension().unwrap_or_default() != "wit" {
+                    continue;
+                }
+                let pkg = UnresolvedPackage::parse_file(&path)
+                    .with_context(|| format!("Error parsing {path:?}"))?;
+                pkgs.insert(pkg.name);
+                deps.extend(pkg.foreign_deps.into_keys());
+            }
+        }
+        Ok((pkgs, deps))
+    }
+
+    async fn pull(
+        &self,
+        client: &mut warg_loader::Client,
+        versioned_pkg: &VersionedPackageName,
+    ) -> Result<Option<(Release, DecodedWasm)>> {
+        let pkg_ref = versioned_pkg.name.to_string().parse()?;
+
+        let versions = client.list_all_versions(&pkg_ref).await?;
+        let Some(version) = versions
+            .into_iter()
+            .filter(|version| {
+                if let Some(expected) = &versioned_pkg.version {
+                    expected.matches(version)
+                } else {
+                    true
+                }
+            })
+            .max()
+        else {
+            return Ok(None);
+        };
+        log::debug!("Resolved {versioned_pkg} to version {version}");
+
+        let release = client.get_release(&pkg_ref, &version).await?;
+
+        let stream = client.stream_content(&pkg_ref, &release).await?;
         let stream = StreamReader::new(stream.map_err(|err| match err {
             warg_loader::Error::IoError(err) => err,
             other => std::io::Error::other(other),
@@ -164,24 +208,67 @@ impl Dep {
 
         let decoded = tokio::task::block_in_place(|| wit_component::decode_reader(reader))?;
 
-        let wit =
-            wit_component::WitPrinter::default().print(decoded.resolve(), decoded.package())?;
+        Ok(Some((release, decoded)))
+    }
 
-        // TODO: instead, hash existing file and compare w/ release.content_digest above
-        let existing = std::fs::read(&self.path).unwrap_or_default();
-        if wit.as_bytes() == existing {
-            return Ok(None);
+    fn write_package(&self, resolve: &Resolve, package_id: PackageId) -> Result<PathBuf> {
+        let wit = wit_component::WitPrinter::default().print(resolve, package_id)?;
+        let pkg = &resolve.packages[package_id];
+
+        let file_version = pkg
+            .name
+            .version
+            .as_ref()
+            .map(
+                |version| match (version.major, version.minor, version.patch) {
+                    (0, 0, patch) => format!("@0.0.{patch}"),
+                    (0, minor, _) => format!("@0.{minor}"),
+                    (major, _, _) => format!("@{major}"),
+                },
+            )
+            .unwrap_or_default();
+        let file_name = format!(
+            "{namespace}-{name}{file_version}.wit",
+            namespace = pkg.name.namespace,
+            name = pkg.name.name,
+        );
+        let path = self.deps_dir()?.join(file_name);
+        log::debug!("Writing to {path:?}");
+
+        let mut file =
+            tempfile::NamedTempFile::with_prefix_in(".tmp-wit-pull-", path.parent().unwrap())?;
+        file.write_all(wit.as_bytes())?;
+        file.persist_noclobber(&path)
+            .or_else(|err| Err(err.error).context(format!("Failed to write {path:?}")))?;
+
+        Ok(path)
+    }
+
+    fn deps_dir(&self) -> Result<PathBuf> {
+        let path = self.wit_dir.join("deps");
+        if !path.exists() {
+            if self.create_dirs {
+                log::info!("Creating {path:?}");
+                std::fs::create_dir_all(&path)?;
+            } else {
+                bail!("Deps dir does not exist at {path:?}");
+            }
         }
-
-        atomic_write(&self.path, wit.as_bytes())?;
-        Ok(Some(latest))
+        Ok(path)
     }
 }
 
-fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
-    let mut file =
-        tempfile::NamedTempFile::with_prefix_in(".tmp-wit-pull-", path.parent().unwrap())?;
-    file.write_all(contents)?;
-    file.persist(path)?;
-    Ok(())
+fn version_satisfied(expected: &VersionedPackageName, actual: &PackageName) -> bool {
+    if expected.name.namespace() != actual.namespace || expected.name.name() != actual.name {
+        return false;
+    }
+    match (&expected.version, &actual.version) {
+        (Some(expected), Some(actual)) => expected.matches(actual),
+        (None, _) => true,
+        _ => false,
+    }
+}
+
+fn wit_to_warg_package_name(wit: &PackageName) -> warg_protocol::registry::PackageName {
+    format!("{}:{}", wit.namespace, wit.name).parse().unwrap()
 }

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -49,6 +49,10 @@ impl PullCommand {
 
         // Determine set of packages to pull
         let packages = if self.packages.is_empty() {
+            // Warn on unparsable root package; might unexpectedly be missing deps
+            if let Err(err) = UnresolvedPackage::parse_dir(&self.wit_dir) {
+                terminal.warn(format!("Couldn't parse root package: {err}"))?;
+            }
             // No packages specified; pull missing dependencies
             pkgs_state
                 .missing_deps()

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -22,7 +22,7 @@ pub struct PullCommand {
     #[clap(flatten)]
     pub common: CommonOptions,
 
-    /// Use the specified registry name when pulling the package(s).
+    /// Use the specified registry name as the default when pulling package(s).
     #[clap(long, value_name = "REGISTRY")]
     pub registry: Option<String>,
 
@@ -85,6 +85,9 @@ impl PullCommand {
             config.namespace_registry("wasi", "bytecodealliance.org");
             if let Some(file_config) = ClientConfig::from_default_file()? {
                 config.merge_config(file_config);
+            }
+            if let Some(registry) = self.registry.clone() {
+                config.default_registry(registry);
             }
             config.to_client()
         };

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -219,13 +219,7 @@ impl PullCommand {
             .name
             .version
             .as_ref()
-            .map(
-                |version| match (version.major, version.minor, version.patch) {
-                    (0, 0, patch) => format!("@0.0.{patch}"),
-                    (0, minor, _) => format!("@0.{minor}"),
-                    (major, _, _) => format!("@{major}"),
-                },
-            )
+            .map(|version| format!("@{version}"))
             .unwrap_or_default();
         let file_name = format!(
             "{namespace}-{name}{file_version}.wit",

--- a/crates/wit/src/commands/pull.rs
+++ b/crates/wit/src/commands/pull.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use clap::Args;
 
 use cargo_component_core::{command::CommonOptions, VersionedPackageName};
@@ -115,9 +115,7 @@ impl PullCommand {
 
                     if let Some(wit_version) = &root_pkg.name.version {
                         let release_version = &release.version;
-                        if wit_version != release_version {
-                            terminal.warn(format!("Release version {release_version} doesn't match WIT package version {wit_version}"))?;
-                        }
+                        ensure!(wit_version == release_version, "release version {release_version} doesn't match WIT package version {wit_version}");
                     }
 
                     for (package_id, package) in &decoded.resolve().packages {


### PR DESCRIPTION
This implements a `wit pull` subcommand which can be used to update local e.g. `wit/deps/*.wit` from a registry.



```console
$ wit pull wasi:io --create-dirs
   Resolving package wasi:io
  Downloaded release wasi:io@0.2.0
       Wrote package wasi:io@0.2.0 to 'wit/deps/wasi-io@0.2.0.wit'

$ head -n1 wit/deps/wasi-io@0.2.0.wit
package wasi:io@0.2.0;

$ wit pull wasi:http
   Resolving package wasi:http
  Downloaded release wasi:http@0.2.0
       Wrote package wasi:clocks@0.2.0 to 'wit/deps/wasi-clocks@0.2.0.wit'
       Wrote package wasi:random@0.2.0 to 'wit/deps/wasi-random@0.2.0.wit'
       Wrote package wasi:cli@0.2.0 to 'wit/deps/wasi-cli@0.2.0.wit'
       Wrote package wasi:http@0.2.0 to 'wit/deps/wasi-http@0.2.0.wit'
```

There are two modes of operation:

- When given specific name(s) it will pull those registry package(s) and unpack all (not existing) WIT packages into `wit/deps/<namespace>-<name>@<version>.wit`
- When given no name(s) it will check the packages under `wit/` for missing dependencies and attempt to pull them like above

Both of these can operate whether or not `wit_parser::Resolve::push_dir` can currently parse the `wit/` directory. If it _can_ parse, the existing dependency checks will just be more accurate (capturing e.g. `wit/deps/some-package.wasm`). This ought to be more consistent but really needs some refactoring in `wit-parser` first.