### PR TITLE
Help mesasage improvement (#138)

### DIFF
--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -5,6 +5,9 @@ use clap::{ArgAction, Args};
 
 /// Common options for commands.
 #[derive(Args)]
+#[command(after_help =
+"Unrecognized subcommands will be passed to cargo verbatim after relevant component bindings are updated."
+)]
 pub struct CommonOptions {
     /// Do not print log messages
     #[clap(long = "quiet", short = 'q')]

--- a/crates/core/src/command.rs
+++ b/crates/core/src/command.rs
@@ -5,8 +5,8 @@ use clap::{ArgAction, Args};
 
 /// Common options for commands.
 #[derive(Args)]
-#[command(after_help =
-"Unrecognized subcommands will be passed to cargo verbatim after relevant component bindings are updated."
+#[command(
+    after_help = "Unrecognized subcommands will be passed to cargo verbatim after relevant component bindings are updated."
 )]
 pub struct CommonOptions {
     /// Do not print log messages


### PR DESCRIPTION
This pull request add a message displayed after the help message, which notifies the unrecognized subcommands are passed to cargo. 

Refer to #138  for details