### PR TITLE
Update to latest Warg release to support registry federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static 1.4.0",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +893,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1009,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1538,7 +1570,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -1856,7 +1888,16 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.13.0",
+]
+
+[[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive 0.14.0",
 ]
 
 [[package]]
@@ -1874,12 +1915,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static 1.4.0",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.3",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "logos-derive"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.13.0",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen 0.14.0",
 ]
 
 [[package]]
@@ -1914,21 +1979,21 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "5.10.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
+ "cfg-if",
  "miette-derive",
- "once_cell",
  "thiserror",
  "unicode-width",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "5.10.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2586,11 +2651,11 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057237efdb71cf4b3f9396302a3d6599a92fa94063ba537b66130980ea9909f3"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
 dependencies = [
- "logos",
+ "logos 0.14.0",
  "miette",
  "once_cell",
  "prost",
@@ -2608,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "protox"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bb76c5f6221de491fe2c8f39b106330bbd9762c6511119c07940e10eb9ff11"
+checksum = "a29b3c5596eb23a849deba860b53ffd468199d9ad5fe4402a7d55379e16aa2d2"
 dependencies = [
  "bytes",
  "miette",
@@ -2623,11 +2688,11 @@ dependencies = [
 
 [[package]]
 name = "protox-parse"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4581f441c58863525a3e6bec7b8de98188cf75239a56c725a3e7288450a33f"
+checksum = "033b939d76d358f7c32120c86c71f515bae45e64f2bde455200356557276276c"
 dependencies = [
- "logos",
+ "logos 0.13.0",
  "miette",
  "prost-types",
  "thiserror",
@@ -3176,6 +3241,12 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3819,9 +3890,8 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bf1e22e1e396b98a2181219b06d1a49a3478c1b9d87a29cd9cd819d714e6c3"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3834,15 +3904,15 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56cfaf9781ca2d084468bbdd8bbc1e35947bb2a19f8d3940d899852f6dd78aa"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
  "bytes",
  "clap",
+ "dialoguer",
  "dirs",
  "futures-util",
  "indexmap 2.2.6",
@@ -3878,9 +3948,8 @@ dependencies = [
 
 [[package]]
 name = "warg-credentials"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626224ba1a00965282b669d2611654fd6292a15396ed8c850ce91684678fe19f"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3892,9 +3961,8 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a8c47e96a7f1903931b34db9a1f0d22bcb3761a203ee6861db686daaedcb4b"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "base64",
@@ -3913,9 +3981,8 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed0e698efd0fab8bb747efd452156a65149eb389f7fe2a6b6b3ced4e25ab24"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -3932,9 +3999,8 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69be98a2e9e0aeace7cbd62184b11462d259c5e391e6208d59506c9a2d33571c"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "base64",
@@ -3955,9 +4021,8 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f15457ced83df5c2298f225fc83b6700e93c7bf320a2e4ef01114c0b34d7ce"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3986,9 +4051,8 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d272b3002b9e5f6f636817089ba091e1ba7b85858e72529f96e24bc9827f530"
+version = "0.5.0-dev"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,6 @@ dependencies = [
  "pretty_env_logger",
  "rand_core",
  "rpassword",
- "secrecy",
  "semver",
  "serde 1.0.197",
  "serde_json",
@@ -571,7 +570,6 @@ dependencies = [
  "toml_edit 0.22.9",
  "url",
  "warg-client",
- "warg-credentials",
  "warg-crypto",
  "warg-protocol",
  "warg-server",
@@ -597,7 +595,6 @@ dependencies = [
  "libc",
  "log",
  "owo-colors",
- "secrecy",
  "semver",
  "serde 1.0.197",
  "tokio",
@@ -3890,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b556c2cc6a4fcac4f50587bb62b04d1c722943702c659b31e16240311588f8f"
+checksum = "b08e86feb745fa5a4e9b3ed8c53ca7353ce474c9164573e7963c65eab0e20998"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3905,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f99db16e7821706e7f4efe2a4a10c7dd7d4545a42c87e2d6bef77283a14b096"
+checksum = "ecb95cdddbc52c73e774d6d555412bb8060156f1ac666df733c18bdeb923c22c"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3919,6 +3916,7 @@ dependencies = [
  "futures-util",
  "indexmap 2.2.6",
  "itertools 0.12.1",
+ "keyring",
  "libc",
  "normpath",
  "once_cell",
@@ -3950,23 +3948,18 @@ dependencies = [
 
 [[package]]
 name = "warg-credentials"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87b014f5773027bdaa4c407ea72a84889a583e48f67ec2b21b490a27313d68a"
+checksum = "bcad56900cb6a983c7090569a7eaa0774db22ade370e39d67a0c3b77354e6abd"
 dependencies = [
- "anyhow",
- "indexmap 2.2.6",
- "keyring",
- "secrecy",
  "warg-client",
- "warg-crypto",
 ]
 
 [[package]]
 name = "warg-crypto"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394967bc096c72ef524de2bd64f0a516e0c4378ca89b88838bb5d64311fdb224"
+checksum = "79344c8bd2cf133533ce6352b6491fbb343e374a8c09527073adda5015c89c92"
 dependencies = [
  "anyhow",
  "base64",
@@ -3985,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bf18aec939aa032f89fe05ac1957002c6619eabf58a74e88e300657ec4087e"
+checksum = "975e38d2ddba1d26f46713d75cccecf3769ebaae7d14b0dcb830d207867c50bf"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4004,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b00c0564b6d52db574b2345dae2918f138dab82a341ef4da61e611eb679a8ee"
+checksum = "fb997bf019742f796123539e9c9031d3ec8ed973950a0534e1f6af508e27e4f1"
 dependencies = [
  "anyhow",
  "base64",
@@ -4027,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bf9d3e34eabe867432fe08a9f5d05c4b34d49d1b1ff516265b901fe75d33b"
+checksum = "a8ada7d9f5ec554959501509b60229da52f5bd0e535b6b83eef2ca4f7f47d127"
 dependencies = [
  "anyhow",
  "axum",
@@ -4058,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1592ffca976471c8b998a176faa5da328ca99ddba1858c5a3dac149cf4557c8"
+checksum = "f04b4573fd7c7ebee61f5b4645b464e7dcd656386d0ca4c77b37533ad1bb98d9"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be8bc4c6b6e9d85ecdad090fcf342a9216f53d747a537cc05e3452fd650ca46"
+checksum = "363387f0019d714aa60cc30ab4fe501a747f4c08fc58f069dd14be971bd495a0"
 dependencies = [
  "byteorder",
  "lazy_static 1.4.0",
@@ -3890,8 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "warg-api"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b556c2cc6a4fcac4f50587bb62b04d1c722943702c659b31e16240311588f8f"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3904,8 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "warg-client"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f99db16e7821706e7f4efe2a4a10c7dd7d4545a42c87e2d6bef77283a14b096"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3948,8 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "warg-credentials"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87b014f5773027bdaa4c407ea72a84889a583e48f67ec2b21b490a27313d68a"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3961,8 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "warg-crypto"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394967bc096c72ef524de2bd64f0a516e0c4378ca89b88838bb5d64311fdb224"
 dependencies = [
  "anyhow",
  "base64",
@@ -3981,8 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protobuf"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bf18aec939aa032f89fe05ac1957002c6619eabf58a74e88e300657ec4087e"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -3999,8 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "warg-protocol"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b00c0564b6d52db574b2345dae2918f138dab82a341ef4da61e611eb679a8ee"
 dependencies = [
  "anyhow",
  "base64",
@@ -4021,8 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "warg-server"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687bf9d3e34eabe867432fe08a9f5d05c4b34d49d1b1ff516265b901fe75d33b"
 dependencies = [
  "anyhow",
  "axum",
@@ -4051,8 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "warg-transparency"
-version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1592ffca976471c8b998a176faa5da328ca99ddba1858c5a3dac149cf4557c8"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "warg-api"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "warg-client"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3949,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "warg-credentials"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "warg-crypto"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "base64",
@@ -3982,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "warg-protobuf"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "pbjson",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "warg-protocol"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "base64",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "warg-server"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "axum",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "warg-transparency"
 version = "0.5.0-dev"
-source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=3eb6368#3eb63685df8f485d84ffefb35216e387ea31eab7"
+source = "git+https://github.com/calvinrp/bytecodealliance-registry?rev=a692b15#a692b158a1c7a059f68746c3558b8ef0b836d46b"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = "0.4.2"
-warg-crypto = "0.4.2"
-warg-client = "0.4.2"
-warg-credentials = "0.4.2"
-warg-server = "0.4.2"
+warg-protocol = "0.4.3"
+warg-crypto = "0.4.3"
+warg-client = "0.4.3"
+warg-credentials = "0.4.3"
+warg-server = "0.4.3"
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ libc = { workspace = true }
 warg-protocol = { workspace = true }
 warg-crypto = { workspace = true }
 warg-client = { workspace = true }
-warg-credentials = { workspace = true }
 p256 = { workspace = true }
 rand_core = { workspace = true }
 rpassword = { workspace = true }
@@ -53,7 +52,6 @@ futures = { workspace = true }
 bytes = { workspace = true }
 which = { workspace = true }
 shell-escape = "0.1.5"
-secrecy = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
@@ -69,11 +67,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = "0.5.0"
-warg-crypto = "0.5.0"
-warg-client = "0.5.0"
-warg-credentials = "0.5.0"
-warg-server = "0.5.0"
+warg-protocol = "0.6.0"
+warg-crypto = "0.6.0"
+warg-client = "0.6.0"
+warg-credentials = "0.6.0"
+warg-server = "0.6.0"
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }
@@ -102,7 +100,6 @@ rpassword = "7.3.1"
 futures = "0.3.30"
 bytes = "1.6.0"
 which = "6.0.1"
-secrecy = "0.8.0"
 wit-bindgen-rust = "0.24.0"
 wit-bindgen-core = "0.24.0"
 tempfile = "3.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = "0.4.1"
-warg-crypto = "0.4.1"
-warg-client = "0.4.1"
-warg-credentials = "0.4.1"
-warg-server = "0.4.1"
+warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
+warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
+warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
+warg-credentials = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
+warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
-warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
-warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
-warg-credentials = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
-warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "3eb6368" }
+warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
+warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
+warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
+warg-credentials = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
+warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
-warg-crypto = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
-warg-client = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
-warg-credentials = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
-warg-server = { git = "https://github.com/calvinrp/bytecodealliance-registry", rev = "a692b15" }
+warg-protocol = "0.4.2"
+warg-crypto = "0.4.2"
+warg-client = "0.4.2"
+warg-credentials = "0.4.2"
+warg-server = "0.4.2"
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,11 @@ members = ["crates/core", "crates/wit"]
 
 [workspace.dependencies]
 cargo-component-core = { path = "crates/core", version = "0.11.0" }
-warg-protocol = "0.4.3"
-warg-crypto = "0.4.3"
-warg-client = "0.4.3"
-warg-credentials = "0.4.3"
-warg-server = "0.4.3"
+warg-protocol = "0.5.0"
+warg-crypto = "0.5.0"
+warg-client = "0.5.0"
+warg-credentials = "0.5.0"
+warg-server = "0.5.0"
 anyhow = "1.0.82"
 clap = { version = "4.5.4", features = ["derive"] }
 toml_edit = { version = "0.22.9", features = ["serde"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,7 +28,6 @@ wit-component = { workspace = true }
 wit-parser = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
-secrecy = { workspace = true }
 clap = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -8,7 +8,6 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use futures::{stream::FuturesUnordered, StreamExt};
 use indexmap::IndexMap;
-use secrecy::Secret;
 use semver::{Comparator, Op, Version, VersionReq};
 use serde::{
     de::{self, value::MapAccessDeserializer},
@@ -24,9 +23,8 @@ use std::{
 use url::Url;
 use warg_client::{
     storage::{ContentStorage, PackageInfo},
-    Config, FileSystemClient, RegistryUrl, StorageLockResult,
+    Config, FileSystemClient, StorageLockResult,
 };
-use warg_credentials::keyring::get_auth_token;
 use warg_crypto::hash::AnyHash;
 use warg_protocol::registry;
 use wit_component::DecodedWasm;
@@ -51,30 +49,13 @@ pub fn find_url<'a>(
     }
 }
 
-/// Gets the auth token for the given registry URL.
-pub fn auth_token(config: &Config, registry: Option<String>) -> Result<Option<Secret<String>>> {
-    if config.keyring_auth {
-        return if let Some(reg_url) = registry {
-            Ok(get_auth_token(&RegistryUrl::new(reg_url)?)?)
-        } else if let Some(url) = config.home_url.as_ref() {
-            Ok(get_auth_token(&RegistryUrl::new(url)?)?)
-        } else {
-            Ok(None)
-        };
-    }
-    Ok(None)
-}
 /// Creates a registry client with the given warg configuration.
 pub fn create_client(
     config: &warg_client::Config,
     url: &str,
     terminal: &Terminal,
 ) -> Result<FileSystemClient> {
-    match FileSystemClient::try_new_with_config(
-        Some(url),
-        config,
-        auth_token(config, Some(url.to_string()))?,
-    )? {
+    match FileSystemClient::try_new_with_config(Some(url), config, None)? {
         StorageLockResult::Acquired(client) => Ok(client),
         StorageLockResult::NotAcquired(path) => {
             terminal.status_with_color(
@@ -83,11 +64,7 @@ pub fn create_client(
                 Colors::Cyan,
             )?;
 
-            Ok(FileSystemClient::new_with_config(
-                Some(url),
-                config,
-                auth_token(config, Some(url.to_string()))?,
-            )?)
+            Ok(FileSystemClient::new_with_config(Some(url), config, None)?)
         }
     }
 }

--- a/crates/wit/src/commands/key.rs
+++ b/crates/wit/src/commands/key.rs
@@ -7,8 +7,8 @@ use clap::{Args, Subcommand};
 use p256::ecdsa::SigningKey;
 use rand_core::OsRng;
 use std::io::{self, Write};
+use warg_client::keyring as warg_keyring;
 use warg_client::Config;
-use warg_credentials::keyring as warg_keyring;
 use warg_crypto::signing::PrivateKey;
 use warg_keyring::{delete_signing_key, get_signing_key, set_signing_key};
 

--- a/crates/wit/src/commands/publish.rs
+++ b/crates/wit/src/commands/publish.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::{Context, Result};
 use cargo_component_core::{command::CommonOptions, registry::find_url};
 use clap::Args;
-use warg_credentials::keyring::get_signing_key;
+use warg_client::keyring::get_signing_key;
 use warg_crypto::signing::PrivateKey;
 use warg_protocol::registry::PackageName;
 

--- a/crates/wit/src/lib.rs
+++ b/crates/wit/src/lib.rs
@@ -328,8 +328,7 @@ async fn publish_wit_package(options: PublishOptions<'_>, terminal: &Terminal) -
 
     let bytes = add_registry_metadata(options.config, &bytes)?;
     let name = options.package.unwrap_or(&name);
-    let mut client = create_client(options.warg_config, options.url, terminal)?;
-    client.refresh_namespace(name.namespace()).await?;
+    let client = create_client(options.warg_config, options.url, terminal)?;
 
     let content = client
         .content()

--- a/crates/wit/tests/support/mod.rs
+++ b/crates/wit/tests/support/mod.rs
@@ -120,7 +120,7 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
         keyring_auth: false,
         ignore_federation_hints: false,
         auto_accept_federation_hints: false,
-        disable_dialoguer: true,
+        disable_interactive: true,
     };
 
     Ok((instance, config))

--- a/crates/wit/tests/support/mod.rs
+++ b/crates/wit/tests/support/mod.rs
@@ -118,6 +118,9 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
         namespace_map_path: Some(root.join("namespaces")),
         keys: IndexSet::new(),
         keyring_auth: false,
+        ignore_federation_hints: false,
+        auto_accept_federation_hints: false,
+        disable_dialoguer: true,
     };
 
     Ok((instance, config))

--- a/src/commands/key.rs
+++ b/src/commands/key.rs
@@ -5,7 +5,7 @@ use clap::{Args, Subcommand};
 use p256::ecdsa::SigningKey;
 use rand_core::OsRng;
 use std::io::{self, Write};
-use warg_credentials::keyring as warg_keyring;
+use warg_client::keyring as warg_keyring;
 use warg_crypto::signing::PrivateKey;
 use warg_keyring::{delete_signing_key, get_signing_key, set_signing_key};
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 use cargo_component_core::{command::CommonOptions, registry::find_url};
 use clap::Args;
 use std::path::PathBuf;
-use warg_credentials::keyring::get_signing_key;
+use warg_client::keyring::get_signing_key;
 use warg_crypto::signing::PrivateKey;
 
 /// Publish a package to a registry.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1095,8 +1095,7 @@ pub async fn publish(config: &Config, options: &PublishOptions<'_>) -> Result<()
         return Ok(());
     }
 
-    let mut client = create_client(config.warg(), options.registry_url, config.terminal())?;
-    client.refresh_namespace(options.name.namespace()).await?;
+    let client = create_client(config.warg(), options.registry_url, config.terminal())?;
 
     let bytes = fs::read(options.path).with_context(|| {
         format!(

--- a/tests/publish.rs
+++ b/tests/publish.rs
@@ -90,7 +90,9 @@ world foo {
         .cargo_component("publish")
         .env("CARGO_COMPONENT_PUBLISH_KEY", test_signing_key())
         .assert()
-        .stderr(contains("error: package `test:foo` does not exist"))
+        .stderr(contains(
+            "package `test:foo` must be initialized before publishing",
+        ))
         .failure();
 
     Ok(())

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -196,7 +196,7 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
         keyring_auth: false,
         ignore_federation_hints: false,
         auto_accept_federation_hints: false,
-        disable_dialoguer: true,
+        disable_interactive: true,
     };
 
     Ok((instance, config))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -194,6 +194,9 @@ pub async fn spawn_server(root: &Path) -> Result<(ServerInstance, warg_client::C
         namespace_map_path: Some(root.join("namespaces")),
         keys: IndexSet::new(),
         keyring_auth: false,
+        ignore_federation_hints: false,
+        auto_accept_federation_hints: false,
+        disable_dialoguer: true,
     };
 
     Ok((instance, config))


### PR DESCRIPTION
This is a small update to update to the latest [Warg release](https://github.com/bytecodealliance/registry/releases/tag/v0.4.2). Supports federation across registries.