### PR TITLE
Add `profile.release` to `Cargo.toml` generated by `cargo component new`

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -245,6 +245,18 @@ impl NewCommand {
             doc["lib"]["crate-type"] = value(Value::from_iter(["cdylib"]));
         }
 
+        // add release profile
+        let mut release_profile = table();
+        release_profile["codegen-units"] = value(1);
+        release_profile["opt-level"] = value("s");
+        release_profile["debug"] = value(false);
+        release_profile["strip"] = value(true);
+        release_profile["lto"] = value(true);
+        let mut profile = table();
+        profile.as_table_mut().unwrap().set_implicit(true);
+        profile["release"] = release_profile;
+        doc["profile"] = profile;
+
         let mut component = Table::new();
         component.set_implicit(true);
 


### PR DESCRIPTION
This adds a default `[profile.release]`:

```toml
[profile.release]
codegen-units = 1
opt-level = "s"
debug = false
strip = true
lto = true
```

The `cargo component build --release` of the `cargo component new --lib` output goes from `1.6 MB` -> `52 KB`.