### PR TITLE
Rename `wasm32-wasi` to `wasm32-wasip1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
         rustup update stable --no-self-update
         rustup update nightly --no-self-update
         rustup default stable
-        rustup target add wasm32-wasi
-        rustup target add wasm32-wasi --toolchain nightly
+        rustup target add wasm32-wasip1
+        rustup target add wasm32-wasip1 --toolchain nightly
         rustup target add wasm32-unknown-unknown
         rustup component add rustfmt
         rustup component add rustfmt --toolchain nightly
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update stable --no-self-update && rustup default stable && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+      run: rustup update stable --no-self-update && rustup default stable && rustup target add wasm32-wasip1 && rustup target add wasm32-unknown-unknown
     - name: Install cargo-component (debug)
       run: cargo install --locked --debug --path .
     - name: Build the example component

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ Until that time, there's `cargo component`!
 
 ## WASI Support
 
-Currently `cargo component` targets `wasm32-wasi` by default.
+Currently `cargo component` targets `wasm32-wasip1` by default.
 
 As this target is for a _preview1_ release of WASI, the WebAssembly module
 produced by the Rust compiler must be adapted to the _preview2_ version of WASI
 supported by the component model.
 
-The adaptation is automatically performed when `wasm32-wasi` is targeted using
+The adaptation is automatically performed when `wasm32-wasip1` is targeted using
 a built-in WASI adapter snapshotted out of the Wasmtime repository.
 
 You may override the built-in adapter `cargo component` uses by setting the

--- a/example/README.md
+++ b/example/README.md
@@ -1,14 +1,14 @@
 # Component example
 
-This directory contains an example component implementing a simple "passthrough 
-cache" service responsible for fetching the content bytes of a given URL from a 
+This directory contains an example component implementing a simple "passthrough
+cache" service responsible for fetching the content bytes of a given URL from a
 supplied origin service.
 
-The component imports two interfaces: a cache implementation for storing 
-previously fetched content and an "origin" backend implementation for 
+The component imports two interfaces: a cache implementation for storing
+previously fetched content and an "origin" backend implementation for
 forwarding the request to when there is a cache miss.
 
-It exports the same backend interface as it imports, effectively wrapping the 
+It exports the same backend interface as it imports, effectively wrapping the
 provided import interface with some simplistic caching logic.
 
 ## Building the component
@@ -19,4 +19,4 @@ To build the component, run the following command:
 cargo component build
 ```
 
-The component should now exist at `target/wasm32-wasi/debug/service.wasm`.
+The component should now exist at `target/wasm32-wasip1/debug/service.wasm`.

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -17,7 +17,7 @@ pub struct PublishCommand {
     #[clap(flatten)]
     pub common: CommonOptions,
 
-    /// Build for the target triple (defaults to `wasm32-wasi`)
+    /// Build for the target triple (defaults to `wasm32-wasip1`)
     #[clap(long = "target", value_name = "TRIPLE")]
     pub target: Option<String>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod registry;
 mod target;
 
 fn is_wasm_target(target: &str) -> bool {
-    target == "wasm32-wasi" || target == "wasm32-unknown-unknown"
+    target == "wasm32-wasi" || target == "wasm32-wasip1" || target == "wasm32-unknown-unknown"
 }
 
 /// Represents a cargo package paired with its component metadata.
@@ -194,9 +194,9 @@ pub async fn run_cargo_command(
     if command.buildable() {
         install_wasm32_wasi(config)?;
 
-        // Add an implicit wasm32-wasi target if there isn't a wasm target present
+        // Add an implicit wasm32-wasip1 target if there isn't a wasm target present
         if !cargo_args.targets.iter().any(|t| is_wasm_target(t)) {
-            cargo.arg("--target").arg("wasm32-wasi");
+            cargo.arg("--target").arg("wasm32-wasip1");
         }
 
         if let Some(format) = &cargo_args.message_format {
@@ -263,11 +263,11 @@ fn get_runner(serve: bool) -> Result<PathAndArgs> {
     let cargo_config = cargo_config2::Config::load()?;
 
     // We check here before we actually build that a runtime is present.
-    // We first check the runner for `wasm32-wasi` in the order from
+    // We first check the runner for `wasm32-wasip1` in the order from
     // cargo's convention for a user-supplied runtime (path or executable)
     // and use the default, namely `wasmtime`, if it is not set.
     let (runner, using_default) = cargo_config
-        .runner(TargetTripleRef::from("wasm32-wasi"))
+        .runner(TargetTripleRef::from("wasm32-wasip1"))
         .unwrap_or_default()
         .map(|runner_override| (runner_override, false))
         .unwrap_or_else(|| {
@@ -294,7 +294,7 @@ fn get_runner(serve: bool) -> Result<PathAndArgs> {
         if !(runner.path.exists() || which::which(&runner.path).is_ok()) {
             bail!(
                 "failed to find `{wasi_runner}` specified by either the `CARGO_TARGET_WASM32_WASI_RUNNER`\
-                environment variable or as the `wasm32-wasi` runner in `.cargo/config.toml`"
+                environment variable or as the `wasm32-wasip1` runner in `.cargo/config.toml`"
             );
         }
     } else if which::which(&runner.path).is_err() {

--- a/src/target.rs
+++ b/src/target.rs
@@ -7,35 +7,35 @@ use std::{
 
 use crate::config::Config;
 
-pub fn install_wasm32_wasi(config: &Config) -> Result<()> {
+pub fn install_wasm32_wasip1(config: &Config) -> Result<()> {
     let sysroot = get_sysroot()?;
-    if sysroot.join("lib/rustlib/wasm32-wasi").exists() {
+    if sysroot.join("lib/rustlib/wasm32-wasip1").exists() {
         return Ok(());
     }
 
     if env::var_os("RUSTUP_TOOLCHAIN").is_none() {
         bail!(
-            "failed to find the `wasm32-wasi` target \
+            "failed to find the `wasm32-wasip1` target \
              and `rustup` is not available. If you're using rustup \
              make sure that it's correctly installed; if not, make sure to \
-             install the `wasm32-wasi` target before using this command"
+             install the `wasm32-wasip1` target before using this command"
         );
     }
 
     config
         .terminal()
-        .status("Installing", "wasm32-wasi target")?;
+        .status("Installing", "wasm32-wasip1 target")?;
 
     let output = Command::new("rustup")
         .arg("target")
         .arg("add")
-        .arg("wasm32-wasi")
+        .arg("wasm32-wasip1")
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit())
         .output()?;
 
     if !output.status.success() {
-        bail!("failed to install the `wasm32-wasi` target");
+        bail!("failed to install the `wasm32-wasip1` target");
     }
 
     Ok(())

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -290,14 +290,14 @@ impl Project {
 
     pub fn debug_wasm(&self, name: &str) -> PathBuf {
         self.build_dir()
-            .join("wasm32-wasi")
+            .join("wasm32-wasip1")
             .join("debug")
             .join(format!("{name}.wasm"))
     }
 
     pub fn release_wasm(&self, name: &str) -> PathBuf {
         self.build_dir()
-            .join("wasm32-wasi")
+            .join("wasm32-wasip1")
             .join("release")
             .join(format!("{name}.wasm"))
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,7 +14,7 @@ fn it_runs_test_with_command_component() -> Result<()> {
     fs::write(
         project.root().join(".cargo/config.toml"),
         r#"
-[target.wasm32-wasi]
+[target.wasm32-wasip1]
 runner = [
     "wasmtime",
     "-C",


### PR DESCRIPTION
The upstream Rust target is being renamed, but with no other changes. The renamed target is now available in the previous stable release (1.78) and the current stable and onwards (1.79+). This renames various references internally in `cargo component` to get users working with the new target.