### PR TITLE
feat(*)!: Adds back support for the offline flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "wasm-pkg-client"
 version = "0.4.1"
-source = "git+https://github.com/bytecodealliance/wasm-pkg-tools.git?rev=47ad11a549c23ac48ecee9226d395fc7c6063250#47ad11a549c23ac48ecee9226d395fc7c6063250"
+source = "git+https://github.com/bytecodealliance/wasm-pkg-tools.git?rev=c48006aa1bcff1e69f4f8fc6689249b314985ab1#c48006aa1bcff1e69f4f8fc6689249b314985ab1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "wasm-pkg-common"
 version = "0.4.1"
-source = "git+https://github.com/bytecodealliance/wasm-pkg-tools.git?rev=47ad11a549c23ac48ecee9226d395fc7c6063250#47ad11a549c23ac48ecee9226d395fc7c6063250"
+source = "git+https://github.com/bytecodealliance/wasm-pkg-tools.git?rev=c48006aa1bcff1e69f4f8fc6689249b314985ab1#c48006aa1bcff1e69f4f8fc6689249b314985ab1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ warg-protocol = "0.7.0"
 warg-server = "0.7.0"
 wasi-preview1-component-adapter-provider = "23.0.1"
 wasm-metadata = "0.208.1"
-wasm-pkg-client = { git = "https://github.com/bytecodealliance/wasm-pkg-tools.git", rev = "47ad11a549c23ac48ecee9226d395fc7c6063250" }
+wasm-pkg-client = { git = "https://github.com/bytecodealliance/wasm-pkg-tools.git", rev = "c48006aa1bcff1e69f4f8fc6689249b314985ab1" }
 wasmparser = "0.208.1"
 wasmprinter = "0.208.1"
 wat = "1.208.1"

--- a/crates/wit/src/commands/add.rs
+++ b/crates/wit/src/commands/add.rs
@@ -14,12 +14,12 @@ use wasm_pkg_client::{caching::FileCache, PackageRef};
 use crate::config::{Config, CONFIG_FILE_NAME};
 
 async fn resolve_version(
-    pkg_config: wasm_pkg_client::Config,
+    pkg_config: Option<wasm_pkg_client::Config>,
     package: &VersionedPackageName,
     registry: &Option<String>,
     file_cache: FileCache,
 ) -> Result<String> {
-    let mut resolver = DependencyResolver::new(pkg_config, None, file_cache);
+    let mut resolver = DependencyResolver::new(pkg_config, None, file_cache)?;
     let dependency = Dependency::Package(RegistryPackage {
         name: Some(package.name.clone()),
         version: package
@@ -113,7 +113,8 @@ impl AddCommand {
             }
             None => {
                 let version =
-                    resolve_version(pkg_config, &self.package, &self.registry, file_cache).await?;
+                    resolve_version(Some(pkg_config), &self.package, &self.registry, file_cache)
+                        .await?;
 
                 let package = RegistryPackage {
                     name: self.name.is_some().then(|| self.package.name.clone()),

--- a/crates/wit/src/lib.rs
+++ b/crates/wit/src/lib.rs
@@ -47,10 +47,10 @@ async fn resolve_dependencies(
         .transpose()?;
 
     let mut resolver = DependencyResolver::new(
-        pkg_config,
+        Some(pkg_config),
         lock_file.as_ref().map(LockFileResolver::new),
         file_cache,
-    );
+    )?;
 
     for (name, dep) in &config.dependencies {
         resolver.add_dependency(name, dep).await?;
@@ -389,7 +389,7 @@ pub async fn update_lockfile(
     file_cache: FileCache,
 ) -> Result<()> {
     // Resolve all dependencies as if the lock file does not exist
-    let mut resolver = DependencyResolver::new(pkg_config, None, file_cache);
+    let mut resolver = DependencyResolver::new(Some(pkg_config), None, file_cache)?;
     for (name, dep) in &config.dependencies {
         resolver.add_dependency(name, dep).await?;
     }

--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
             }
 
             let spawn_args: Vec<_> = std::env::args().skip(1).collect();
-            let client = config.client(cache_dir).await?;
+            let client = config.client(cache_dir, cargo_args.offline).await?;
             if let Err(e) = run_cargo_command(
                 client,
                 &config,

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -73,7 +73,7 @@ impl AddCommand {
         let config = Config::new(self.common.new_terminal(), self.common.config.clone())?;
         let metadata = load_metadata(self.manifest_path.as_deref())?;
 
-        let client = config.client(self.common.cache_dir.clone()).await?;
+        let client = config.client(self.common.cache_dir.clone(), false).await?;
 
         let spec = match &self.spec {
             Some(spec) => Some(spec.clone()),
@@ -130,7 +130,7 @@ impl AddCommand {
         client: Arc<CachingClient<FileCache>>,
         name: &PackageRef,
     ) -> Result<String> {
-        let mut resolver = DependencyResolver::new_with_client(client, None);
+        let mut resolver = DependencyResolver::new_with_client(client, None)?;
         let dependency = Dependency::Package(RegistryPackage {
             name: Some(self.package.name.clone()),
             version: self

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -158,7 +158,7 @@ impl NewCommand {
             Some(s) => Some(format!("{s}@{version}", version = VersionReq::STAR).parse()?),
             None => None,
         };
-        let client = config.client(self.common.cache_dir.clone()).await?;
+        let client = config.client(self.common.cache_dir.clone(), false).await?;
         let target = self.resolve_target(client, target).await?;
         let source = self.generate_source(&target).await?;
 
@@ -531,7 +531,7 @@ world example {{
                 package,
                 world,
             }) => {
-                let mut resolver = DependencyResolver::new_with_client(client, None);
+                let mut resolver = DependencyResolver::new_with_client(client, None)?;
                 let dependency = Dependency::Package(package);
 
                 resolver.add_dependency(&name, &dependency).await?;

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -83,7 +83,7 @@ impl PublishCommand {
         log::debug!("executing publish command");
 
         let config = Config::new(self.common.new_terminal(), self.common.config.clone())?;
-        let client = config.client(self.common.cache_dir.clone()).await?;
+        let client = config.client(self.common.cache_dir.clone(), false).await?;
 
         if let Some(target) = &self.target {
             if !is_wasm_target(target) {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -43,7 +43,7 @@ impl UpdateCommand {
         let packages = load_component_metadata(&metadata, [].iter(), true)?;
 
         let lock_update_allowed = !self.frozen && !self.locked;
-        let client = config.client(self.common.cache_dir).await?;
+        let client = config.client(self.common.cache_dir, false).await?;
         crate::update_lockfile(
             client,
             &config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -532,9 +532,10 @@ impl Config {
     pub async fn client(
         &self,
         cache: Option<PathBuf>,
+        offline: bool,
     ) -> anyhow::Result<Arc<CachingClient<FileCache>>> {
         Ok(Arc::new(CachingClient::new(
-            Client::new(self.pkg_config.clone()),
+            (!offline).then(|| Client::new(self.pkg_config.clone())),
             FileCache::new(cache_dir(cache)?).await?,
         )))
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -60,7 +60,7 @@ impl<'a> PackageDependencyResolution<'a> {
             return Ok(Default::default());
         }
 
-        let mut resolver = DependencyResolver::new_with_client(client, lock_file);
+        let mut resolver = DependencyResolver::new_with_client(client, lock_file)?;
 
         for (name, dependency) in target_deps.iter() {
             resolver.add_dependency(name, dependency).await?;
@@ -78,7 +78,7 @@ impl<'a> PackageDependencyResolution<'a> {
             return Ok(Default::default());
         }
 
-        let mut resolver = DependencyResolver::new_with_client(client, lock_file);
+        let mut resolver = DependencyResolver::new_with_client(client, lock_file)?;
 
         for (name, dependency) in &metadata.section.dependencies {
             resolver.add_dependency(name, dependency).await?;


### PR DESCRIPTION
This adds back in support for offline deps. It required a change to the dependency resolver to error early if offline was requested without a lock file present