### PR TITLE
Add ability to customize bindings output path without BC breaks.

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -60,6 +60,8 @@ impl FromStr for Ownership {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct Bindings {
+    /// The path where bindings will be generated (default to `src/bindings.rs`).
+    pub path: PathBuf,
     /// Whether or not to run `rustfmt` on the bindings; defaults to true.
     pub format: bool,
     /// The ownership model for generated types.
@@ -106,6 +108,7 @@ pub struct Bindings {
 impl Default for Bindings {
     fn default() -> Self {
         Self {
+            path: PathBuf::from("src/bindings.rs"),
             format: true,
             ownership: Default::default(),
             derives: Default::default(),


### PR DESCRIPTION
Hi!

Thank you for the fantastic work on cargo-component!

This is PR is an alternative proposal to #316 that aims to address #315 in a backward-compatible manner.

#### What could be added to this PR furthermore?

- Test cases
- Documentation update

#### How to change bindings output path using code in this PR

1. Move the component declaration to a dedicated module of your choosing (here `wasi`):

```rust
// src/wasi.rs
pub mod bindings;

use bindings::Guest;

struct Component;

impl Guest for Component {
  ...
}

bindings::export!(Component with_types_in bindings);
```
(component declaration stays the same)

2. Register the new `wasi` module inside your `lib`:

```rust
// src/lib.rs
#[cfg(target_os = "wasi")] // ymmv
pub mod wasi;
```

3. Change bindings generation path to `src/wasi/bindings.rs` by adding a metadata inside the `Cargo.toml` manifest:

```toml
# Cargo.toml
[package.metadata.component.bindings]
path = "src/wasi/bindings.rs"
```

This way, we don't break current behaviour while allowing the bindings output path to change.