### PR TITLE
Avoid overwriting `bindings.rs` if content is unchanged

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,13 +855,14 @@ async fn generate_package_bindings(
             path = output_dir.display()
         )
     })?;
-
-    fs::write(&bindings_path, bindings).with_context(|| {
-        format!(
-            "failed to write bindings file `{path}`",
-            path = bindings_path.display()
-        )
-    })?;
+    if fs::read_to_string(&bindings_path).unwrap_or_default() != bindings {
+        fs::write(&bindings_path, bindings).with_context(|| {
+            format!(
+                "failed to write bindings file `{path}`",
+                path = bindings_path.display()
+            )
+        })?;
+    }
 
     Ok(import_name_map)
 }


### PR DESCRIPTION
Compare the contents of `bindings.rs` before overwriting. If no changes are detected, skip the overwrite to prevent unnecessary recompilation.