### PR TITLE
Add a `bindings` subcommand.

### DIFF
--- a/src/bin/cargo-component.rs
+++ b/src/bin/cargo-component.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 use cargo_component::{
-    commands::{AddCommand, NewCommand, PublishCommand, UpdateCommand},
+    commands::{AddCommand, BindingsCommand, NewCommand, PublishCommand, UpdateCommand},
     config::{CargoArguments, Config},
     load_component_metadata, load_metadata, run_cargo_command,
 };
@@ -19,6 +19,7 @@ fn version() -> &'static str {
 /// The list of commands that are built-in to `cargo-component`.
 const BUILTIN_COMMANDS: &[&str] = &[
     "add",
+    "bindings",
     "component", // for indirection via `cargo component`
     "help",
     "init",
@@ -71,6 +72,7 @@ enum CargoComponent {
 #[derive(Parser)]
 enum Command {
     Add(AddCommand),
+    Bindings(BindingsCommand),
     // TODO: Init(InitCommand),
     New(NewCommand),
     // TODO: Remove(RemoveCommand),
@@ -115,6 +117,7 @@ async fn main() -> Result<()> {
             if let Err(e) = match CargoComponent::parse() {
                 CargoComponent::Component(cmd) | CargoComponent::Command(cmd) => match cmd {
                     Command::Add(cmd) => cmd.exec().await,
+                    Command::Bindings(cmd) => cmd.exec().await,
                     Command::New(cmd) => cmd.exec().await,
                     Command::Update(cmd) => cmd.exec().await,
                     Command::Publish(cmd) => cmd.exec().await,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,11 +1,13 @@
 //! Commands for the `cargo-component` CLI.
 
 mod add;
+mod bindings;
 mod new;
 mod publish;
 mod update;
 
 pub use self::add::*;
+pub use self::bindings::*;
 pub use self::new::*;
 pub use self::publish::*;
 pub use self::update::*;

--- a/src/commands/bindings.rs
+++ b/src/commands/bindings.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use cargo_component_core::command::CommonOptions;
+use clap::Args;
+
+use crate::{
+    config::Config, generate_bindings, load_component_metadata, load_metadata, CargoArguments,
+};
+
+/// Just update the generated bindings.
+///
+/// The generated bindings are generated automatically by subcommands like
+/// `cargo component build`; `cargo component bindings` is for when one wishes
+/// to just generate the bindings without doing any other work.
+#[derive(Args)]
+#[clap(disable_version_flag = true)]
+pub struct BindingsCommand {
+    /// The common command options.
+    #[clap(flatten)]
+    pub common: CommonOptions,
+}
+
+impl BindingsCommand {
+    /// Executes the command.
+    pub async fn exec(self) -> Result<()> {
+        log::debug!("generating bindings");
+
+        let config = Config::new(self.common.new_terminal(), self.common.config.clone()).await?;
+
+        let client = config.client(self.common.cache_dir.clone(), false).await?;
+
+        let cargo_args = CargoArguments::parse()?;
+        let metadata = load_metadata(None)?;
+        let packages =
+            load_component_metadata(&metadata, cargo_args.packages.iter(), cargo_args.workspace)?;
+        let _import_name_map =
+            generate_bindings(client, &config, &metadata, &packages, &cargo_args).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add a `bindings` subcommand, which just generates the bindings.rs file.

And make the `new` subcommand auto-generate the bindings.rs file too, so that the tree is fully set up after a `new`.

Fixes #362.