### PR TITLE
Remove generated `[profile.release]` from new projects

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -264,18 +264,6 @@ impl NewCommand {
             doc["lib"]["crate-type"] = value(Value::from_iter(["cdylib"]));
         }
 
-        // add release profile
-        let mut release_profile = table();
-        release_profile["codegen-units"] = value(1);
-        release_profile["opt-level"] = value("s");
-        release_profile["debug"] = value(false);
-        release_profile["strip"] = value(true);
-        release_profile["lto"] = value(true);
-        let mut profile = table();
-        profile.as_table_mut().unwrap().set_implicit(true);
-        profile["release"] = release_profile;
-        doc["profile"] = profile;
-
         let mut component = Table::new();
         component.set_implicit(true);
 


### PR DESCRIPTION
This commit effectively reverts #289 and removes the generated `[profile.release]` section from `Cargo.toml` when executing `cargo component new`. The PR mentions that a default release build decreases from 1.6M to 52KB and that was likely due to stripping DWARF debugging information rather than many of the other settings configured. Nowadays for example a default release build (with no extra configuration and no `profile.release`) is around 50KB because rustc/cargo have started stripping debuginfo by default in release mode. That means that the original motivation is still solved, the "default" build is not an alarmingly large 1.6M.

Otherwise the various settings configured here can have negative effects which aren't always easy to debug if you're not familiar with them, for example:

* `lto = true` and `codegen-units = 1` can massively increase the time needed for a build. This can be surprising to newcomers who may have heard about Rust compile times being bad but this is an order of magnitude worse than the default settings. While these two options are good rules-of-thumb for a minimally-sized build not everyone falls into the category of needing a minimally sized build, and users can always configure this themselves.

* `debug = false` is not necessary as it's already the default of the `profile.release` in Cargo.

* `strip = true` is no longer necessary in recent versions of rustc/Cargo because this is done by default for debuginfo. This is otherwise somewhat harmful as it strips the `name` custom section which hinders any after-the-fact analysis of a binary because there is no symbol information to profile with, for example.

* `opt-level = "s"` is not universally smaller than the default `opt-level = "3"` and it can also perform significantly worse. An example component I was working with today had a 100% slowdown using `opt-level = "s"` relative to `opt-level = "3"`.

Overall I think it's best to inherit Cargo's and Rust's defaults for these settings by default. There's no one-size-fits-all for all projects which is why Cargo allows configuring things, but for a template I think it's best to inherit default settings since that'll ideally cause the least surprise for users who aren't otherwise familiar with these settings.