### PR TITLE
set version to 0.21.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 readme = "README.md"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
@@ -72,7 +72,7 @@ anyhow = "1.0.82"
 assert_cmd = "2.0.14"
 bytes = "1.6.0"
 cargo_metadata = "0.19.1"
-cargo-component-core = { path = "crates/core", version = "0.21.0" }
+cargo-component-core = { path = "crates/core", version = "0.21.1" }
 cargo-config2 = "0.1.24"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 dirs = "5"


### PR DESCRIPTION
just a patch release: only change from 0.21.0 is https://github.com/bytecodealliance/cargo-component/pull/381 which pins a dep to not use semver