### PR TITLE
Get async options from package metadata

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -19,7 +19,10 @@ use wit_parser::{
     World, WorldId, WorldItem, WorldKey,
 };
 
-use crate::{metadata::{AsyncConfig, Ownership}, registry::PackageDependencyResolution};
+use crate::{
+    metadata::{AsyncConfig, Ownership},
+    registry::PackageDependencyResolution,
+};
 
 // Used to format `unlocked-dep` import names for dependencies on
 // other components.
@@ -142,7 +145,7 @@ impl<'a> BindingsGenerator<'a> {
                     exports: exports.clone(),
                 },
                 AsyncConfig::All => wit_bindgen_rust::AsyncConfig::All,
-            }
+            },
         };
 
         let mut files = Files::default();

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -12,14 +12,14 @@ use indexmap::{IndexMap, IndexSet};
 use semver::Version;
 use wasm_pkg_client::PackageRef;
 use wit_bindgen_core::Files;
-use wit_bindgen_rust::{AsyncConfig, Opts, WithOption};
+use wit_bindgen_rust::{Opts, WithOption};
 use wit_component::DecodedWasm;
 use wit_parser::{
     Interface, Package, PackageName, Resolve, Type, TypeDefKind, TypeOwner, UnresolvedPackageGroup,
     World, WorldId, WorldItem, WorldKey,
 };
 
-use crate::{metadata::Ownership, registry::PackageDependencyResolution};
+use crate::{metadata::{AsyncConfig, Ownership}, registry::PackageDependencyResolution};
 
 // Used to format `unlocked-dep` import names for dependencies on
 // other components.
@@ -135,9 +135,14 @@ impl<'a> BindingsGenerator<'a> {
             pub_export_macro: settings.pub_export_macro,
             generate_unused_types: settings.generate_unused_types,
             disable_custom_section_link_helpers: settings.disable_custom_section_link_helpers,
-
-            // TODO: pipe this through to the CLI options, requires valid serde impls
-            async_: AsyncConfig::None,
+            async_: match &settings.async_ {
+                AsyncConfig::None => wit_bindgen_rust::AsyncConfig::None,
+                AsyncConfig::Some { imports, exports } => wit_bindgen_rust::AsyncConfig::Some {
+                    imports: imports.clone(),
+                    exports: exports.clone(),
+                },
+                AsyncConfig::All => wit_bindgen_rust::AsyncConfig::All,
+            }
         };
 
         let mut files = Files::default();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -56,6 +56,18 @@ impl FromStr for Ownership {
     }
 }
 
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AsyncConfig {
+    #[default]
+    None,
+    Some {
+        imports: Vec<String>,
+        exports: Vec<String>,
+    },
+    All,
+}
+
 /// Configuration for bindings generation.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -110,6 +122,16 @@ pub struct Bindings {
     /// Disabling this can shave a few bytes off a binary but makes
     /// library-based usage of `generate!` prone to breakage.
     pub disable_custom_section_link_helpers: bool,
+    /// Determines which functions to lift or lower `async`, if any.
+    ///
+    /// Accepted values are:
+    ///     - none
+    ///     - all
+    ///     - some=<value>[,<value>...], where each <value> is of the form:
+    ///         - import:<name> or
+    ///         - export:<name>
+    #[serde(rename = "async")]
+    pub async_: AsyncConfig,
 }
 
 impl Default for Bindings {
@@ -132,6 +154,7 @@ impl Default for Bindings {
             pub_export_macro: Default::default(),
             generate_unused_types: Default::default(),
             disable_custom_section_link_helpers: Default::default(),
+            async_: Default::default(),
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -123,13 +123,6 @@ pub struct Bindings {
     /// library-based usage of `generate!` prone to breakage.
     pub disable_custom_section_link_helpers: bool,
     /// Determines which functions to lift or lower `async`, if any.
-    ///
-    /// Accepted values are:
-    ///     - none
-    ///     - all
-    ///     - some=<value>[,<value>...], where each <value> is of the form:
-    ///         - import:<name> or
-    ///         - export:<name>
     #[serde(rename = "async")]
     pub async_: AsyncConfig,
 }


### PR DESCRIPTION
Not sure if it would be preferred to have `wit_bindgen_rust::AsyncConfig` implement `serde::Deserialize`, instead of creating a copy of the enum in this repo that implements it.

But I figured it is still useful to allow configuring the async options in `cargo-component` in the meantime, and remove the enum copy if `wit_bindgen_rust::AsyncConfig` implements it in the future