### PR TITLE
git2 dep: set default-features = false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,8 +1458,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -2080,9 +2078,7 @@ checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -2094,20 +2090,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2505,24 +2487,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ bytes = "1.6.0"
 cargo_metadata = "0.19.1"
 cargo-component-core = { path = "crates/core", version = "0.21.1" }
 cargo-config2 = "0.1.24"
-git2 = "0.20.1"
+git2 = { version = "0.20.1", default-features = false }
 clap = { version = "4.5.4", features = ["derive", "env"] }
 dirs = "5"
 futures = "0.3.30"


### PR DESCRIPTION
https://github.com/bytecodealliance/cargo-component/pull/383 broke the binary build https://github.com/bytecodealliance/cargo-component/actions/runs/14040229083, which is not checked prior to merge. The root cause is depending on OpenSSL in a cross-compiling context, which was not trivial to resolve. But there is also no reason to actually depend on OpenSSL, since our use of `git2` isn't related to connecting to servers. So, this PR disables all of the features of git2, because they are not needed.
