### PR TITLE
CI workflow: upgrade sccache-action to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
+      uses: mozilla-actions/sccache-action@v0.0.8
     - name: Install Rust
       run: |
         rustup set profile minimal


### PR DESCRIPTION
CI is broken currently, apparently because sccache-action@v0.0.4 is using an azure service that was taken offline on April 15:

https://github.com/bytecodealliance/cargo-component/actions/runs/14503281869/job/40687667218#step:7:15