### PR TITLE
Add a more specific suggestion when failing to select a default world.

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -362,7 +362,8 @@ impl<'a> BindingsGenerator<'a> {
                     )
                 }
                 None => format!(
-                    "failed to select the default world to use for local target `{path}`",
+                    "failed to select the default world to use for local target `{path}`. \
+                     Please ensure that a world is specified in Cargo.toml under [package.metadata.component.target].",
                     path = path.display()
                 ),
             })?;


### PR DESCRIPTION
Resolves https://github.com/bytecodealliance/cargo-component/issues/227.

Note: I originally wanted to only add the hint specifically when the "multiple worlds found in package" error arose, but this appears to be happening within the `wit-parser` crate, where this hint wouldn't make sense.

Thus, (since the hint doesn't make sense there) this seems like the best place to put it.